### PR TITLE
NULLのMaterialPathを保存時、クラッシュする不具合修正

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
@@ -340,7 +340,7 @@ void EffectImplemented::Load( void* pData, int size, float mag, const EFK_CHAR* 
 	m_pRoot = EffectNode::Create( this, NULL, pos );
 
 	// リロード用にmaterialPathを記録しておく
-	m_materialPath = materialPath;
+    if (materialPath) m_materialPath = materialPath;
 
 	ReloadResources( materialPath );
 }


### PR DESCRIPTION
エディタが非アクティブ状態から復帰するとクラッシュしました
