### PR TITLE
batファイルの改行コードを必ず\r\nにするようにした

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat eol=crlf


### PR DESCRIPTION
batファイルを実行すると改行コードの違いでコマンドが連なった状態になったので、gitで同期するときに必ず\r\nにするようにしました。
