### PR TITLE
ネットワーク接続中に項目を高速に変化させたときに落ちるバグを修正

### DIFF
--- a/Dev/Editor/EffekseerCore/Utl/TextureInformation.cs
+++ b/Dev/Editor/EffekseerCore/Utl/TextureInformation.cs
@@ -20,7 +20,7 @@ namespace Effekseer.Utl
 			System.IO.FileStream fs = null;
 			try
 			{
-				fs = System.IO.File.Open(path, System.IO.FileMode.Open);
+				fs = System.IO.File.Open(path, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read);
 			}
 			catch(System.IO.FileNotFoundException e)
 			{


### PR DESCRIPTION
ネットワーク接続中に項目を高速に変化させたときに落ちるバグを修正を発見したので修正しました。
