### PR TITLE
画像ファイル名の表示ラベルにツールチップを追加（画像ファイル名がラベルからはみ出してもマウスカーソルを当てると画像ファイルのパスが表示される）

### DIFF
--- a/Dev/Editor/Effekseer/GUI/Component/PathForImage.cs
+++ b/Dev/Editor/Effekseer/GUI/Component/PathForImage.cs
@@ -72,6 +72,7 @@ namespace Effekseer.GUI.Component
 			{
 				btn_load.Enabled = true;
 				lbl_file.Text = binding.GetRelativePath();
+                tooltip_file.SetToolTip(lbl_file, lbl_file.Text);
 				if (lbl_file.Text.Length > 0)
 				{
 					UpdatePreview(binding.GetAbsolutePath());

--- a/Dev/Editor/Effekseer/GUI/Component/PathForImage.designer.cs
+++ b/Dev/Editor/Effekseer/GUI/Component/PathForImage.designer.cs
@@ -28,78 +28,80 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.btn_load = new System.Windows.Forms.Button();
-			this.lbl_file = new System.Windows.Forms.Label();
-			this.pic_preview = new System.Windows.Forms.PictureBox();
-			this.lbl_info = new System.Windows.Forms.Label();
-			this.btn_delete = new System.Windows.Forms.Button();
-			((System.ComponentModel.ISupportInitialize)(this.pic_preview)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// btn_load
-			// 
-			this.btn_load.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-			this.btn_load.Location = new System.Drawing.Point(0, 0);
-			this.btn_load.Name = "btn_load";
-			this.btn_load.Size = new System.Drawing.Size(40, 20);
-			this.btn_load.TabIndex = 0;
-			this.btn_load.Text = "読込";
-			this.btn_load.UseVisualStyleBackColor = true;
-			this.btn_load.Click += new System.EventHandler(this.btn_load_Click);
-			// 
-			// lbl_file
-			// 
-			this.lbl_file.AutoSize = true;
-			this.lbl_file.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-			this.lbl_file.Location = new System.Drawing.Point(42, 5);
-			this.lbl_file.Name = "lbl_file";
-			this.lbl_file.Size = new System.Drawing.Size(29, 11);
-			this.lbl_file.TabIndex = 1;
-			this.lbl_file.Text = "none";
-			// 
-			// pic_preview
-			// 
-			this.pic_preview.Location = new System.Drawing.Point(0, 40);
-			this.pic_preview.Name = "pic_preview";
-			this.pic_preview.Size = new System.Drawing.Size(128, 128);
-			this.pic_preview.TabIndex = 2;
-			this.pic_preview.TabStop = false;
-			// 
-			// lbl_info
-			// 
-			this.lbl_info.AutoSize = true;
-			this.lbl_info.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-			this.lbl_info.Location = new System.Drawing.Point(42, 24);
-			this.lbl_info.Name = "lbl_info";
-			this.lbl_info.Size = new System.Drawing.Size(29, 11);
-			this.lbl_info.TabIndex = 3;
-			this.lbl_info.Text = "none";
-			// 
-			// btn_delete
-			// 
-			this.btn_delete.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-			this.btn_delete.Location = new System.Drawing.Point(0, 19);
-			this.btn_delete.Name = "btn_delete";
-			this.btn_delete.Size = new System.Drawing.Size(40, 20);
-			this.btn_delete.TabIndex = 4;
-			this.btn_delete.Text = "解除";
-			this.btn_delete.UseVisualStyleBackColor = true;
-			this.btn_delete.Click += new System.EventHandler(this.btn_delete_Click);
-			// 
-			// PathForImage
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.btn_delete);
-			this.Controls.Add(this.lbl_info);
-			this.Controls.Add(this.pic_preview);
-			this.Controls.Add(this.lbl_file);
-			this.Controls.Add(this.btn_load);
-			this.Name = "PathForImage";
-			this.Size = new System.Drawing.Size(148, 169);
-			((System.ComponentModel.ISupportInitialize)(this.pic_preview)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.components = new System.ComponentModel.Container();
+            this.btn_load = new System.Windows.Forms.Button();
+            this.lbl_file = new System.Windows.Forms.Label();
+            this.pic_preview = new System.Windows.Forms.PictureBox();
+            this.lbl_info = new System.Windows.Forms.Label();
+            this.btn_delete = new System.Windows.Forms.Button();
+            this.tooltip_file = new System.Windows.Forms.ToolTip(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.pic_preview)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // btn_load
+            // 
+            this.btn_load.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.btn_load.Location = new System.Drawing.Point(0, 0);
+            this.btn_load.Name = "btn_load";
+            this.btn_load.Size = new System.Drawing.Size(40, 20);
+            this.btn_load.TabIndex = 0;
+            this.btn_load.Text = "読込";
+            this.btn_load.UseVisualStyleBackColor = true;
+            this.btn_load.Click += new System.EventHandler(this.btn_load_Click);
+            // 
+            // lbl_file
+            // 
+            this.lbl_file.AutoSize = true;
+            this.lbl_file.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lbl_file.Location = new System.Drawing.Point(42, 5);
+            this.lbl_file.Name = "lbl_file";
+            this.lbl_file.Size = new System.Drawing.Size(29, 11);
+            this.lbl_file.TabIndex = 1;
+            this.lbl_file.Text = "none";
+            // 
+            // pic_preview
+            // 
+            this.pic_preview.Location = new System.Drawing.Point(0, 40);
+            this.pic_preview.Name = "pic_preview";
+            this.pic_preview.Size = new System.Drawing.Size(128, 128);
+            this.pic_preview.TabIndex = 2;
+            this.pic_preview.TabStop = false;
+            // 
+            // lbl_info
+            // 
+            this.lbl_info.AutoSize = true;
+            this.lbl_info.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lbl_info.Location = new System.Drawing.Point(42, 24);
+            this.lbl_info.Name = "lbl_info";
+            this.lbl_info.Size = new System.Drawing.Size(29, 11);
+            this.lbl_info.TabIndex = 3;
+            this.lbl_info.Text = "none";
+            // 
+            // btn_delete
+            // 
+            this.btn_delete.Font = new System.Drawing.Font("MS UI Gothic", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.btn_delete.Location = new System.Drawing.Point(0, 19);
+            this.btn_delete.Name = "btn_delete";
+            this.btn_delete.Size = new System.Drawing.Size(40, 20);
+            this.btn_delete.TabIndex = 4;
+            this.btn_delete.Text = "解除";
+            this.btn_delete.UseVisualStyleBackColor = true;
+            this.btn_delete.Click += new System.EventHandler(this.btn_delete_Click);
+            // 
+            // PathForImage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btn_delete);
+            this.Controls.Add(this.lbl_info);
+            this.Controls.Add(this.pic_preview);
+            this.Controls.Add(this.lbl_file);
+            this.Controls.Add(this.btn_load);
+            this.Name = "PathForImage";
+            this.Size = new System.Drawing.Size(148, 169);
+            ((System.ComponentModel.ISupportInitialize)(this.pic_preview)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -110,5 +112,6 @@
 		private System.Windows.Forms.PictureBox pic_preview;
 		private System.Windows.Forms.Label lbl_info;
 		private System.Windows.Forms.Button btn_delete;
+        private System.Windows.Forms.ToolTip tooltip_file;
 	}
 }

--- a/Dev/Editor/Effekseer/GUI/Component/PathForImage.resx
+++ b/Dev/Editor/Effekseer/GUI/Component/PathForImage.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="tooltip_file.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
画像ファイル名の表示ラベルにツールチップを追加
画像ファイル名がラベルからはみ出してもマウスカーソルを当てると画像ファイルのパスが欠けずに表示されるようにしました