### PR TITLE
fix restore states.

### DIFF
--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.RendererImplemented.h
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.RendererImplemented.h
@@ -10,6 +10,8 @@
 #include "../../EffekseerRendererCommon/EffekseerRenderer.RenderStateBase.h"
 #include "../../EffekseerRendererCommon/EffekseerRenderer.StandardRenderer.h"
 
+#include <array>
+
 #ifdef _MSC_VER
 #include <xmmintrin.h>
 #endif
@@ -301,6 +303,12 @@ private:
 	DWORD	m_state_D3DRS_LIGHTING;
 	DWORD	m_state_D3DRS_SHADEMODE;
 
+	std::array<DWORD, 4>	m_state_D3DSAMP_MAGFILTER;
+	std::array<DWORD, 4>	m_state_D3DSAMP_MINFILTER;
+	std::array<DWORD, 4>	m_state_D3DSAMP_MIPFILTER;
+	std::array<DWORD, 4>	m_state_D3DSAMP_ADDRESSU;
+	std::array<DWORD, 4>	m_state_D3DSAMP_ADDRESSV;
+
 	IDirect3DVertexShader9*			m_state_vertexShader;
 	IDirect3DPixelShader9*			m_state_pixelShader;
 	IDirect3DVertexDeclaration9*	m_state_vertexDeclaration;
@@ -311,7 +319,10 @@ private:
 
 	IDirect3DIndexBuffer9*	m_state_IndexData;
 
-	IDirect3DBaseTexture9*	m_state_pTexture;
+	std::vector<float>	m_state_VertexShaderConstantF;
+	std::vector<float>	m_state_PixelShaderConstantF;
+
+	std::array<IDirect3DBaseTexture9*, 2>	m_state_pTexture;
 
 	bool	m_isChangedDevice;
 

--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.Shader.h
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.Shader.h
@@ -74,8 +74,8 @@ public:
 	void* GetVertexConstantBuffer() { return m_vertexConstantBuffer; }
 	void* GetPixelConstantBuffer() { return m_pixelConstantBuffer; }
 
-	void SetVertexRegisterCount(int32_t count){ m_vertexRegisterCount = count; }
-	void SetPixelRegisterCount(int32_t count){ m_pixelRegisterCount = count; }
+	void SetVertexRegisterCount(int32_t count){ assert( count <= 256 ); m_vertexRegisterCount = count; }
+	void SetPixelRegisterCount(int32_t count){ assert( count <= 256 ); m_pixelRegisterCount = count; }
 
 	void SetConstantBuffer();
 };


### PR DESCRIPTION
Add `SetSamplerState(0,1,2,3)`, `SetTexture(1)`, `SetVertexShaderConstantF()`, `SetPixelShaderConstantF()`, `SetStreamSource(0)`, `SetIndices()` to restore processing.

`SetTexture(1)` may be used [here](https://github.com/effekseer/Effekseer/blob/d50cba4fe6e7b28d62f0be9f995ef6c2fbfa55dc/Dev/Cpp/EffekseerRendererCommon/EffekseerRenderer.StandardRenderer.h#L258), etc.
`SetSamplerState(0, 1, 2, 3)` is used [here](https://github.com/effekseer/Effekseer/blob/04219d5bda5b751d392fd65f85916fce947bb7f8/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.RenderState.cpp#L139-L154).
Since we do not know the size of `SetVertexShaderConstantF()` and `SetPixelShaderConstantF()`, added assert it with 256 or less.