### PR TITLE
added CMakeLists.txt to EffekseerRendererDX12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,6 @@ set(PNG_TESTS OFF CACHE BOOL "" FORCE)
 add_subdirectory(Downloads/libpng)
 set_target_properties(png_static PROPERTIES FOLDER "ThirdParty/png")
 set_target_properties(genfiles PROPERTIES FOLDER "ThirdParty/png")
-set_target_properties(genprebuilt PROPERTIES FOLDER "ThirdParty/png")
-set_target_properties(gensym PROPERTIES FOLDER "ThirdParty/png")
-set_target_properties(genvers PROPERTIES FOLDER "ThirdParty/png")
-set_target_properties(symbol-check PROPERTIES FOLDER "ThirdParty/png")
 
 # glfw
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)

--- a/Dev/Cpp/CMakeLists.txt
+++ b/Dev/Cpp/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 option(USE_OPENGLES2 "Use OpenGL ES2" OFF)
 option(USE_OPENGLES3 "Use OpenGL ES3" OFF)
 option(USE_OPENGL3 "Use OpenGL 3" OFF)
+option(USE_LLGI "Use LLGI" OFF)
 
 if (MSVC)
 option(USE_OPENAL "Use OpenAL" OFF)
@@ -210,6 +211,11 @@ endif()
 
 if (USE_OSM OR BUILD_VIEWER)
 	add_subdirectory("EffekseerSoundOSMixer")
+endif()
+
+if (USE_LLGI)
+	add_subdirectory(3rdParty/LLGI)
+	add_subdirectory(EffekseerRendererDX12)
 endif()
 
 # Flags

--- a/Dev/Cpp/EffekseerRendererDX12/CMakeLists.txt
+++ b/Dev/Cpp/EffekseerRendererDX12/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required (VERSION 3.0.0)
+project(EffekseerRendererDX12)
+
+#--------------------
+# Files
+
+file(GLOB_RECURSE LOCAL_SOURCES_Common ../EffekseerRendererCommon/*.h ../EffekseerRendererCommon/*.cpp)
+source_group("EffekseerRendererCommon" FILES ${LOCAL_SOURCES_Common})
+
+file(GLOB_RECURSE LOCAL_HEADERS_DX12 *.h)
+file(GLOB_RECURSE LOCAL_SOURCES_DX12 *.cpp)
+source_group("EffekseerRenderer" FILES ${LOCAL_HEADERS_DX12} ${LOCAL_SOURCES_DX12})
+
+file(GLOB_RECURSE LOCAL_SOURCES_LLGI ../EffekseerRendererLLGI/*.h ../EffekseerRendererLLGI/*.cpp)
+source_group("EffekseerRendererLLGI" FILES ${LOCAL_SOURCES_LLGI})
+
+set(LOCAL_SOURCES
+    ${LOCAL_SOURCES_Common}
+    ${LOCAL_HEADERS_DX12}
+    ${LOCAL_SOURCES_DX12}
+    ${LOCAL_SOURCES_LLGI})
+
+#--------------------
+# Projects
+
+add_library(${PROJECT_NAME} STATIC ${LOCAL_SOURCES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Effekseer ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/LLGI/src)
+target_link_libraries(${PROJECT_NAME} LLGI)
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${LOCAL_HEADERS_DX12}")
+
+#--------------------
+# Install
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-export
+    INCLUDES DESTINATION include/EffekseerRendererDX12
+    PUBLIC_HEADER DESTINATION include/EffekseerRendererDX12
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+
+install(
+    EXPORT ${PROJECT_NAME}-export
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION lib/cmake
+    EXPORT_LINK_INTERFACE_LIBRARIES)


### PR DESCRIPTION
Without the Python build script, genprebuilt, gensym, genvers and symbol-check were unnecessary.