### PR TITLE
fixed a window size issue with Retina display

### DIFF
--- a/Dev/Editor/Effekseer/GUI/Manager.cs
+++ b/Dev/Editor/Effekseer/GUI/Manager.cs
@@ -628,7 +628,7 @@ namespace Effekseer.GUI
 
 		public static void SaveWindowConfig(string path)
 		{
-			var size = Manager.WindowSize;
+			var size = Manager.NativeManager.GetSize();
 
 			System.Xml.XmlDocument doc = new System.Xml.XmlDocument();
 


### PR DESCRIPTION
The window size is doubled each time the application is launched on Macs with Retina Display. This commit fixes it.