### PR TITLE
Refactor around FilterFolder CMake function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,36 +235,6 @@ if(BUILD_VIEWER OR BUILD_EXAMPLES)
     list(APPEND EFK_THIRDPARTY_LIBRARY_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/Install/OpenSoundMixer/lib)
 endif()
 
-
-# a function to generate filters by folders
-function(FilterFolder srcs)
-    foreach(FILE ${srcs}) 
-        # Get the directory of the source file
-        get_filename_component(PARENT_DIR "${FILE}" DIRECTORY)
-    
-        # Remove common directory prefix to make the group
-        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "" GROUP "${PARENT_DIR}")
-    
-        # Make sure we are using windows slashes
-        string(REPLACE "/" "\\" GROUP "${GROUP}")
-    
-        # Group into "Source Files" and "Header Files"
-        if ("${FILE}" MATCHES ".*\\.cpp")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.c")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.cxx")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.h")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.mm")
-           set(GROUP "${GROUP}")
-        endif()
-    
-        source_group("${GROUP}" FILES "${FILE}")
-    endforeach()
-endfunction(FilterFolder)
-
 # resource
 if (BUILD_VIEWER)
     find_package(PythonInterp 3)

--- a/Dev/Cpp/Effekseer/CMakeLists.txt
+++ b/Dev/Cpp/Effekseer/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(Effekseer)
 cmake_minimum_required(VERSION 3.1)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
+include(FilterFolder)
 
 # Setup source codes
 file(GLOB effekseer_h

--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -28,35 +28,6 @@ if (MSVC)
     endif()
 endif()
 
-# a function to generate filters by folders
-function(FilterFolder srcs)
-    foreach(FILE ${srcs}) 
-        # Get the directory of the source file
-        get_filename_component(PARENT_DIR "${FILE}" DIRECTORY)
-    
-        # Remove common directory prefix to make the group
-        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "" GROUP "${PARENT_DIR}")
-    
-        # Make sure we are using windows slashes
-        string(REPLACE "/" "\\" GROUP "${GROUP}")
-    
-        # Group into "Source Files" and "Header Files"
-        if ("${FILE}" MATCHES ".*\\.cpp")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.c")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.cxx")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.h")
-           set(GROUP "${GROUP}")
-        elseif("${FILE}" MATCHES ".*\\.mm")
-           set(GROUP "${GROUP}")
-        endif()
-    
-        source_group("${GROUP}" FILES "${FILE}")
-    endforeach()
-endfunction(FilterFolder)
-
 set(EFK_RUNTIME_ROOT ${CMAKE_CURRENT_LIST_DIR}/src)
 
 add_subdirectory(src)

--- a/cmake/FilterFolder.cmake
+++ b/cmake/FilterFolder.cmake
@@ -1,0 +1,28 @@
+# a function to generate filters by folders
+function(FilterFolder srcs)
+foreach(FILE ${srcs}) 
+    # Get the directory of the source file
+    get_filename_component(PARENT_DIR "${FILE}" DIRECTORY)
+
+    # Remove common directory prefix to make the group
+    string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "" GROUP "${PARENT_DIR}")
+
+    # Make sure we are using windows slashes
+    string(REPLACE "/" "\\" GROUP "${GROUP}")
+
+    # Group into "Source Files" and "Header Files"
+    if ("${FILE}" MATCHES ".*\\.cpp")
+       set(GROUP "${GROUP}")
+    elseif("${FILE}" MATCHES ".*\\.c")
+       set(GROUP "${GROUP}")
+    elseif("${FILE}" MATCHES ".*\\.cxx")
+       set(GROUP "${GROUP}")
+    elseif("${FILE}" MATCHES ".*\\.h")
+       set(GROUP "${GROUP}")
+    elseif("${FILE}" MATCHES ".*\\.mm")
+       set(GROUP "${GROUP}")
+    endif()
+
+    source_group("${GROUP}" FILES "${FILE}")
+endforeach()
+endfunction(FilterFolder)


### PR DESCRIPTION
The `build.Linux.sh` was not passing the CMake phase since it was not finding the `FilterFolder` function. Moreover, the function is declared multiple times in different `CMakeLists.txt` files. Thus, this PR aiming to fix and centralize the FilterFolder usage.