### PR TITLE
Improvement in Linux compilation script

### DIFF
--- a/Dev/build.Linux.sh
+++ b/Dev/build.Linux.sh
@@ -1,3 +1,17 @@
+MSBUILD_EXISTS=`which msbuild >/dev/null 2>&1 ; echo $?`
+if [ ${MSBUILD_EXISTS} -ne 0 ]
+then
+    echo "You need to install 'msbuild'"
+    exit -1
+fi
+
+NUGET_EXISTS=`which nuget >/dev/null 2>&1 ; echo $?`
+if [ ${NUGET_EXISTS} -ne 0 ]
+then
+    echo "You need to install 'nuget' (package manager for C#)"
+    exit -1
+fi
+
 msbuild Editor/EffekseerCore/EffekseerCore.csproj /t:build /p:Configuration=Release /p:Platform=x86
 msbuild Editor/Effekseer/Effekseer.csproj /t:build /p:Configuration=Release /p:Platform=x86
 

--- a/Dev/build.Linux.sh
+++ b/Dev/build.Linux.sh
@@ -12,6 +12,9 @@ then
     exit -1
 fi
 
+nuget install ./Editor/Effekseer/packages.config -o ./Editor/packages/
+nuget install ./Editor/EffekseerCore/packages.config -o ./Editor/packages/
+
 msbuild Editor/EffekseerCore/EffekseerCore.csproj /t:build /p:Configuration=Release /p:Platform=x86
 msbuild Editor/Effekseer/Effekseer.csproj /t:build /p:Configuration=Release /p:Platform=x86
 

--- a/Dev/build.Linux.sh
+++ b/Dev/build.Linux.sh
@@ -1,5 +1,5 @@
-xbuild Editor/EffekseerCore/EffekseerCore.csproj /t:build /p:Configuration=Release /p:Platform=x86
-xbuild Editor/Effekseer/Effekseer.csproj /t:build /p:Configuration=Release /p:Platform=x86
+msbuild Editor/EffekseerCore/EffekseerCore.csproj /t:build /p:Configuration=Release /p:Platform=x86
+msbuild Editor/Effekseer/Effekseer.csproj /t:build /p:Configuration=Release /p:Platform=x86
 
 rm -rf Temp
 


### PR DESCRIPTION
Several improvements for the linux compilation script :
- use of msbuild instead of xbuild (the latest is deprecated. msbuild is also used for MacOS compilation)
- checks for msbuild and nuget before running script
- use of nuget to install dependencies in the expected folder