### PR TITLE
Set C++17 flags since EditorCommon uses std::filesystem

### DIFF
--- a/Dev/Cpp/CMakeLists.txt
+++ b/Dev/Cpp/CMakeLists.txt
@@ -5,11 +5,7 @@ project(Effekseer)
 cmake_minimum_required(VERSION 3.1)
 
 # C++ version
-if(WIN32)
-    set(CMAKE_CXX_STANDARD 17)
-else()
-    set(CMAKE_CXX_STANDARD 14)
-endif()
+set(CMAKE_CXX_STANDARD 17)
 
 # For Mac
 if(APPLE)


### PR DESCRIPTION
C++17 was only enabled for WIN32 platforms but since EditorCommon uses std::filesystem, it is needed everywhere.