### PR TITLE
Fix decimal separator issue with certain input languages (#505)

### DIFF
--- a/Dev/Cpp/Viewer/3rdParty/imgui/imgui_internal.h
+++ b/Dev/Cpp/Viewer/3rdParty/imgui/imgui_internal.h
@@ -1372,6 +1372,7 @@ struct ImGuiContext
     // Platform support
     ImVec2                  PlatformImePos;                     // Cursor position request & last passed to the OS Input Method Editor
     ImVec2                  PlatformImeLastPos;
+    char                    PlatformLocaleDecimalPoint;         // '.' or *localeconv()->decimal_point
     ImGuiViewportP*         PlatformImePosViewport;
 
     // Extensions
@@ -1528,6 +1529,7 @@ struct ImGuiContext
         TooltipOverrideCount = 0;
 
         PlatformImePos = PlatformImeLastPos = ImVec2(FLT_MAX, FLT_MAX);
+        PlatformLocaleDecimalPoint = '.';
         PlatformImePosViewport = 0;
 
         DockContext = NULL;

--- a/Dev/Cpp/Viewer/3rdParty/imgui/imgui_widgets.cpp
+++ b/Dev/Cpp/Viewer/3rdParty/imgui/imgui_widgets.cpp
@@ -3440,12 +3440,21 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
     // Generic named filters
     if (flags & (ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase | ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_CharsScientific))
     {
+        // The libc allows overriding locale, with e.g. 'setlocale(LC_NUMERIC, "de_DE.UTF-8");' which affect the output/input of printf/scanf.
+        // The standard mandate that programs starts in the "C" locale where the decimal point is '.'.
+        // We don't really intend to provide widespread support for it, but out of empathy for people stuck with using odd API, we support the bare minimum aka overriding the decimal point.
+        // Change the default decimal_point with:
+        //   ImGui::GetCurrentContext()->PlatformLocaleDecimalPoint = *localeconv()->decimal_point;
+        ImGuiContext& g = *GImGui;
+        const unsigned c_decimal_point = (unsigned int)g.PlatformLocaleDecimalPoint;
+        
+
         if (flags & ImGuiInputTextFlags_CharsDecimal)
-            if (!(c >= '0' && c <= '9') && (c != '.') && (c != '-') && (c != '+') && (c != '*') && (c != '/'))
+            if (!(c >= '0' && c <= '9') && (c != c_decimal_point) && (c != '-') && (c != '+') && (c != '*') && (c != '/'))
                 return false;
 
         if (flags & ImGuiInputTextFlags_CharsScientific)
-            if (!(c >= '0' && c <= '9') && (c != '.') && (c != '-') && (c != '+') && (c != '*') && (c != '/') && (c != 'e') && (c != 'E'))
+            if (!(c >= '0' && c <= '9') && (c != c_decimal_point)  && (c != '-') && (c != '+') && (c != '*') && (c != '/') && (c != 'e') && (c != 'E'))
                 return false;
 
         if (flags & ImGuiInputTextFlags_CharsHexadecimal)

--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
@@ -731,7 +731,8 @@ bool GUIManager::Initialize(std::shared_ptr<Effekseer::MainWindow> mainWindow, e
 void GUIManager::InitializeGUI(Native* native)
 {
 	ImGui::CreateContext();
-
+	ImGui::GetCurrentContext()->PlatformLocaleDecimalPoint = *localeconv()->decimal_point;
+	
 	ImGuiIO& io = ImGui::GetIO();
 
 	if (deviceType == DeviceType::OpenGL)


### PR DESCRIPTION
This PR applies https://github.com/ocornut/imgui/commit/13f718337ac4df2c66727e85174d48e9a91eabcf in the imgui version used by effekseer and configures it to use the system decimal separator.