### PR TITLE
Repeal EFK_CHAR

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer.h
+++ b/Dev/Cpp/Effekseer/Effekseer.h
@@ -1767,19 +1767,19 @@ public:
 	FileInterface() = default;
 	virtual ~FileInterface() = default;
 
-	virtual FileReader* OpenRead(const EFK_CHAR* path) = 0;
+	virtual FileReader* OpenRead(const char16_t* path) = 0;
 
 	/**
 		@brief
 		\~English	try to open a reader. It need not to succeeds in opening it.
 		\~Japanese	リーダーを開くことを試します。成功する必要はありません。
 	*/
-	virtual FileReader* TryOpenRead(const EFK_CHAR* path)
+	virtual FileReader* TryOpenRead(const char16_t* path)
 	{
 		return OpenRead(path);
 	}
 
-	virtual FileWriter* OpenWrite(const EFK_CHAR* path) = 0;
+	virtual FileWriter* OpenWrite(const char16_t* path) = 0;
 };
 
 } // namespace Effekseer
@@ -1851,9 +1851,9 @@ class DefaultFileInterface : public FileInterface
 {
 private:
 public:
-	FileReader* OpenRead(const EFK_CHAR* path);
+	FileReader* OpenRead(const char16_t* path);
 
-	FileWriter* OpenWrite(const EFK_CHAR* path);
+	FileWriter* OpenWrite(const char16_t* path);
 };
 
 //----------------------------------------------------------------------------------
@@ -1984,7 +1984,7 @@ public:
 	\~English load body data(parameters of effect) from a binary
 	\~Japanese	バイナリから本体(エフェクトのパラメーター)を読み込む。
 	*/
-	bool LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath);
+	bool LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath);
 
 	/**
 	@brief
@@ -2055,14 +2055,14 @@ public:
 		\~English this method is called when load a effect from binary
 		\~Japanese	バイナリからエフェクトを読み込む時に、このメソッドが呼ばれる。
 	*/
-	virtual bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath);
+	virtual bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath);
 
 	/**
 		@brief
 		\~English this method is called when load resources
 		\~Japanese	リソースを読み込む時に、このメソッドが呼ばれる。
 	*/
-	virtual void OnLoadingResource(Effect* effect, const void* data, int32_t size, const EFK_CHAR* materialPath);
+	virtual void OnLoadingResource(Effect* effect, const void* data, int32_t size, const char16_t* materialPath);
 
 	/**
 	@brief
@@ -2109,7 +2109,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Manager* manager, void* data, int32_t size, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Manager* manager, void* data, int32_t size, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 		@brief	エフェクトを生成する。
@@ -2119,7 +2119,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Manager* manager, const EFK_CHAR* path, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Manager* manager, const char16_t* path, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 	@brief	エフェクトを生成する。
@@ -2130,7 +2130,7 @@ public:
 	@param	materialPath	[in]	素材ロード時の基準パス
 	@return	エフェクト。失敗した場合はNULLを返す。
 */
-	static Effect* Create(Setting* setting, void* data, int32_t size, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Setting* setting, void* data, int32_t size, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 		@brief	エフェクトを生成する。
@@ -2140,7 +2140,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Setting* setting, const EFK_CHAR* path, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Setting* setting, const char16_t* path, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 	@brief	標準のエフェクト読込インスタンスを生成する。
@@ -2201,7 +2201,7 @@ public:
 	@brief	\~English	Get a color image's path
 	\~Japanese	色画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetColorImagePath(int n) const = 0;
+	virtual const char16_t* GetColorImagePath(int n) const = 0;
 
 	/**
 	@brief	格納されている法線画像のポインタを取得する。
@@ -2219,7 +2219,7 @@ public:
 	@brief	\~English	Get a normal image's path
 	\~Japanese	法線画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetNormalImagePath(int n) const = 0;
+	virtual const char16_t* GetNormalImagePath(int n) const = 0;
 
 	/**
 	@brief	格納されている歪み画像のポインタを取得する。
@@ -2237,7 +2237,7 @@ public:
 	@brief	\~English	Get a distortion image's path
 	\~Japanese	歪み画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetDistortionImagePath(int n) const = 0;
+	virtual const char16_t* GetDistortionImagePath(int n) const = 0;
 
 	/**
 		@brief	格納されている音波形のポインタを取得する。
@@ -2253,7 +2253,7 @@ public:
 	@brief	\~English	Get a wave's path
 	\~Japanese	音波形のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetWavePath(int n) const = 0;
+	virtual const char16_t* GetWavePath(int n) const = 0;
 
 	/**
 		@brief	格納されているモデルのポインタを取得する。
@@ -2269,7 +2269,7 @@ public:
 	@brief	\~English	Get a model's path
 	\~Japanese	モデルのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetModelPath(int n) const = 0;
+	virtual const char16_t* GetModelPath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a material's pointer
@@ -2287,7 +2287,7 @@ public:
 	@brief	\~English	Get a material's path
 	\~Japanese	マテリアルのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetMaterialPath(int n) const = 0;
+	virtual const char16_t* GetMaterialPath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a curve's pointer
@@ -2305,7 +2305,7 @@ public:
 	@brief	\~English	Get a curve's path
 	\~Japanese	カーブのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetCurvePath(int n) const = 0;
+	virtual const char16_t* GetCurvePath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a procedual model's pointer
@@ -2388,7 +2388,7 @@ public:
 	*/
 	virtual bool Reload(void* data,
 						int32_t size,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -2413,8 +2413,8 @@ public:
 		\~Japanese
 		もし、reloadingThreadType が RenderThreadの場合、新規のリソースは読み込まれず、古いリソースは破棄されない。
 	*/
-	virtual bool Reload(const EFK_CHAR* path,
-						const EFK_CHAR* materialPath = nullptr,
+	virtual bool Reload(const char16_t* path,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -2454,7 +2454,7 @@ public:
 						int32_t managersCount,
 						void* data,
 						int32_t size,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -2489,14 +2489,14 @@ public:
 	*/
 	virtual bool Reload(Manager** managers,
 						int32_t managersCount,
-						const EFK_CHAR* path,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* path,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
 		@brief	画像等リソースの再読み込みを行う。
 	*/
-	virtual void ReloadResources(const void* data = nullptr, int32_t size = 0, const EFK_CHAR* materialPath = nullptr) = 0;
+	virtual void ReloadResources(const void* data = nullptr, int32_t size = 0, const char16_t* materialPath = nullptr) = 0;
 
 	/**
 		@brief	画像等リソースの破棄を行う。
@@ -3528,7 +3528,7 @@ public:
 		エフェクトファイルを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual bool Load(const EFK_CHAR* path, void*& data, int32_t& size) = 0;
+	virtual bool Load(const char16_t* path, void*& data, int32_t& size) = 0;
 
 	/**
 		@brief	エフェクトファイルを破棄する。
@@ -3594,7 +3594,7 @@ public:
 		テクスチャを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual TextureData* Load(const EFK_CHAR* path, TextureType textureType)
+	virtual TextureData* Load(const char16_t* path, TextureType textureType)
 	{
 		return nullptr;
 	}
@@ -3674,7 +3674,7 @@ public:
 	\~English a pointer of loaded a model
 	\~Japanese 読み込まれたモデルのポインタ
 	*/
-	virtual Model* Load(const EFK_CHAR* path);
+	virtual Model* Load(const char16_t* path);
 
 	/**
 		@brief
@@ -3752,7 +3752,7 @@ public:
 		\~English	a pointer of loaded a material
 		\~Japanese	読み込まれたマテリアルのポインタ
 	*/
-	virtual MaterialData* Load(const EFK_CHAR* path)
+	virtual MaterialData* Load(const char16_t* path)
 	{
 		return nullptr;
 	}
@@ -4168,7 +4168,7 @@ public:
 	カーブを読み込む。
 	::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual void* Load(const EFK_CHAR* path)
+	virtual void* Load(const char16_t* path)
 	{
 		::Effekseer::DefaultFileInterface fileInterface;
 		std::unique_ptr<::Effekseer::FileReader>reader(fileInterface.OpenRead(path));
@@ -4365,7 +4365,7 @@ public:
 		サウンドを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual void* Load(const EFK_CHAR* path)
+	virtual void* Load(const char16_t* path)
 	{
 		return NULL;
 	}
@@ -4692,7 +4692,7 @@ public:
 		\~English	an effect to be edit
 		\~Japanese	編集される対象のエフェクト
 	*/
-	virtual void Register(const EFK_CHAR* key, Effect* effect) = 0;
+	virtual void Register(const char16_t* key, Effect* effect) = 0;
 
 	/**
 		@brief
@@ -4724,14 +4724,14 @@ public:
 		\~English	Specify root path to load materials
 		\~Japanese	素材のルートパスを設定する。
 	*/
-	virtual void SetMaterialPath(const EFK_CHAR* materialPath) = 0;
+	virtual void SetMaterialPath(const char16_t* materialPath) = 0;
 
 	/**
 		@brief
 		\~English	deprecated
 		\~Japanese	非推奨
 	*/
-	virtual void Regist(const EFK_CHAR* key, Effect* effect) = 0;
+	virtual void Regist(const char16_t* key, Effect* effect) = 0;
 
 	/**
 		@brief
@@ -4787,8 +4787,8 @@ public:
 	virtual bool Start(char* host, uint16_t port) = 0;
 	virtual void Stop() = 0;
 
-	virtual void Reload(const EFK_CHAR* key, void* data, int32_t size) = 0;
-	virtual void Reload(Manager* manager, const EFK_CHAR* path, const EFK_CHAR* key) = 0;
+	virtual void Reload(const char16_t* key, void* data, int32_t size) = 0;
+	virtual void Reload(Manager* manager, const char16_t* path, const char16_t* key) = 0;
 	virtual bool IsConnected() = 0;
 };
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Client.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Client.cpp
@@ -217,7 +217,7 @@ bool ClientImplemented::Send(void* data, int32_t datasize)
 	return true;
 }
 
-void ClientImplemented::Reload(const EFK_CHAR* key, void* data, int32_t size)
+void ClientImplemented::Reload(const char16_t* key, void* data, int32_t size)
 {
 	int32_t keylen = 0;
 	for (;; keylen++)
@@ -249,7 +249,7 @@ void ClientImplemented::Reload(const EFK_CHAR* key, void* data, int32_t size)
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-void ClientImplemented::Reload(Manager* manager, const EFK_CHAR* path, const EFK_CHAR* key)
+void ClientImplemented::Reload(Manager* manager, const char16_t* path, const char16_t* key)
 {
 	EffectLoader* loader = manager->GetEffectLoader();
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Client.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Client.h
@@ -33,8 +33,8 @@ public:
 	virtual bool Start(char* host, uint16_t port) = 0;
 	virtual void Stop() = 0;
 
-	virtual void Reload(const EFK_CHAR* key, void* data, int32_t size) = 0;
-	virtual void Reload(Manager* manager, const EFK_CHAR* path, const EFK_CHAR* key) = 0;
+	virtual void Reload(const char16_t* key, void* data, int32_t size) = 0;
+	virtual void Reload(Manager* manager, const char16_t* path, const char16_t* key) = 0;
 	virtual bool IsConnected() = 0;
 };
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ClientImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ClientImplemented.h
@@ -50,8 +50,8 @@ public:
 
 	bool Send(void* data, int32_t datasize);
 
-	void Reload(const EFK_CHAR* key, void* data, int32_t size);
-	void Reload(Manager* manager, const EFK_CHAR* path, const EFK_CHAR* key);
+	void Reload(const char16_t* key, void* data, int32_t size);
+	void Reload(Manager* manager, const char16_t* path, const char16_t* key);
 
 	bool IsConnected();
 };

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.CurveLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.CurveLoader.h
@@ -48,7 +48,7 @@ public:
 	カーブを読み込む。
 	::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual void* Load(const EFK_CHAR* path)
+	virtual void* Load(const char16_t* path)
 	{
 		::Effekseer::DefaultFileInterface fileInterface;
 		std::unique_ptr<::Effekseer::FileReader>reader(fileInterface.OpenRead(path));

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.cpp
@@ -33,7 +33,7 @@ DefaultEffectLoader::~DefaultEffectLoader()
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-bool DefaultEffectLoader::Load(const EFK_CHAR* path, void*& data, int32_t& size)
+bool DefaultEffectLoader::Load(const char16_t* path, void*& data, int32_t& size)
 {
 	assert(path != NULL);
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.h
@@ -30,7 +30,7 @@ public:
 
 	virtual ~DefaultEffectLoader();
 
-	bool Load(const EFK_CHAR* path, void*& data, int32_t& size);
+	bool Load(const char16_t* path, void*& data, int32_t& size);
 
 	void Unload(void* data, int32_t size);
 };

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultFile.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultFile.cpp
@@ -128,7 +128,7 @@ size_t DefaultFileWriter::GetLength()
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-FileReader* DefaultFileInterface::OpenRead(const EFK_CHAR* path)
+FileReader* DefaultFileInterface::OpenRead(const char16_t* path)
 {
 	FILE* filePtr = NULL;
 #ifdef _WIN32
@@ -150,7 +150,7 @@ FileReader* DefaultFileInterface::OpenRead(const EFK_CHAR* path)
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-FileWriter* DefaultFileInterface::OpenWrite(const EFK_CHAR* path)
+FileWriter* DefaultFileInterface::OpenWrite(const char16_t* path)
 {
 	FILE* filePtr = NULL;
 #ifdef _WIN32

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultFile.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultFile.h
@@ -64,9 +64,9 @@ class DefaultFileInterface : public FileInterface
 {
 private:
 public:
-	FileReader* OpenRead(const EFK_CHAR* path);
+	FileReader* OpenRead(const char16_t* path);
 
-	FileWriter* OpenWrite(const EFK_CHAR* path);
+	FileWriter* OpenWrite(const char16_t* path);
 };
 
 //----------------------------------------------------------------------------------

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
@@ -28,7 +28,7 @@
 namespace Effekseer
 {
 
-static void PathCombine(EFK_CHAR* dst, const EFK_CHAR* src1, const EFK_CHAR* src2)
+static void PathCombine(char16_t* dst, const char16_t* src1, const char16_t* src2)
 {
 	int len1 = 0, len2 = 0;
 	if (src1 != NULL)
@@ -36,7 +36,7 @@ static void PathCombine(EFK_CHAR* dst, const EFK_CHAR* src1, const EFK_CHAR* src
 		for (len1 = 0; src1[len1] != L'\0'; len1++)
 		{
 		}
-		memcpy(dst, src1, len1 * sizeof(EFK_CHAR));
+		memcpy(dst, src1, len1 * sizeof(char16_t));
 		if (len1 > 0 && src1[len1 - 1] != L'/' && src1[len1 - 1] != L'\\')
 		{
 			dst[len1++] = L'/';
@@ -47,7 +47,7 @@ static void PathCombine(EFK_CHAR* dst, const EFK_CHAR* src1, const EFK_CHAR* src
 		for (len2 = 0; src2[len2] != L'\0'; len2++)
 		{
 		}
-		memcpy(&dst[len1], src2, len2 * sizeof(EFK_CHAR));
+		memcpy(&dst[len1], src2, len2 * sizeof(char16_t));
 	}
 
 	for (int i = 0; i < len1 + len2; i++)
@@ -61,7 +61,7 @@ static void PathCombine(EFK_CHAR* dst, const EFK_CHAR* src1, const EFK_CHAR* src
 	dst[len1 + len2] = L'\0';
 }
 
-static void GetParentDir(EFK_CHAR* dst, const EFK_CHAR* src)
+static void GetParentDir(char16_t* dst, const char16_t* src)
 {
 	int i, last = -1;
 	for (i = 0; src[i] != L'\0'; i++)
@@ -71,7 +71,7 @@ static void GetParentDir(EFK_CHAR* dst, const EFK_CHAR* src)
 	}
 	if (last >= 0)
 	{
-		memcpy(dst, src, last * sizeof(EFK_CHAR));
+		memcpy(dst, src, last * sizeof(char16_t));
 		dst[last] = L'\0';
 	}
 	else
@@ -112,7 +112,7 @@ static std::u16string getFilenameWithoutExt(const char16_t* path)
 	return std::u16string(ret.data());
 }
 
-bool EffectFactory::LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath)
+bool EffectFactory::LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath)
 {
 	auto effect_ = static_cast<EffectImplemented*>(effect);
 	auto data_ = static_cast<const uint8_t*>(data);
@@ -199,12 +199,12 @@ bool EffectFactory::OnCheckIsReloadSupported()
 	return true;
 }
 
-bool EffectFactory::OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath)
+bool EffectFactory::OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath)
 {
 	return this->LoadBody(effect, data, size, magnification, materialPath);
 }
 
-void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t size, const EFK_CHAR* materialPath)
+void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t size, const char16_t* materialPath)
 {
 	auto textureLoader = effect->GetSetting()->GetTextureLoader();
 	auto soundLoader = effect->GetSetting()->GetSoundLoader();
@@ -217,7 +217,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 	{
 		for (auto i = 0; i < effect->GetColorImageCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetColorImagePath(i));
 
 			auto resource = textureLoader->Load(fullPath, TextureType::Color);
@@ -226,7 +226,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 
 		for (auto i = 0; i < effect->GetNormalImageCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetNormalImagePath(i));
 
 			auto resource = textureLoader->Load(fullPath, TextureType::Normal);
@@ -235,7 +235,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 
 		for (auto i = 0; i < effect->GetDistortionImageCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetDistortionImagePath(i));
 
 			auto resource = textureLoader->Load(fullPath, TextureType::Distortion);
@@ -247,7 +247,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 	{
 		for (auto i = 0; i < effect->GetWaveCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetWavePath(i));
 
 			auto resource = soundLoader->Load(fullPath);
@@ -259,7 +259,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 	{
 		for (auto i = 0; i < effect->GetModelCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetModelPath(i));
 
 			auto resource = modelLoader->Load(fullPath);
@@ -271,7 +271,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 	{
 		for (auto i = 0; i < effect->GetMaterialCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetMaterialPath(i));
 
 			auto resource = materialLoader->Load(fullPath);
@@ -283,7 +283,7 @@ void EffectFactory::OnLoadingResource(Effect* effect, const void* data, int32_t 
 	{
 		for (auto i = 0; i < effect->GetCurveCount(); i++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, materialPath, effect->GetCurvePath(i));
 
 			auto resource = curveLoader->Load(fullPath);
@@ -396,12 +396,12 @@ EffectFactory::~EffectFactory()
 {
 }
 
-Effect* Effect::Create(Manager* manager, void* data, int32_t size, float magnification, const EFK_CHAR* materialPath)
+Effect* Effect::Create(Manager* manager, void* data, int32_t size, float magnification, const char16_t* materialPath)
 {
 	return EffectImplemented::Create(manager, data, size, magnification, materialPath);
 }
 
-Effect* Effect::Create(Manager* manager, const EFK_CHAR* path, float magnification, const EFK_CHAR* materialPath)
+Effect* Effect::Create(Manager* manager, const char16_t* path, float magnification, const char16_t* materialPath)
 {
 	Setting* setting = manager->GetSetting();
 
@@ -416,7 +416,7 @@ Effect* Effect::Create(Manager* manager, const EFK_CHAR* path, float magnificati
 	if (!eLoader->Load(path, data, size))
 		return NULL;
 
-	EFK_CHAR parentDir[512];
+	char16_t parentDir[512];
 	if (materialPath == NULL)
 	{
 		GetParentDir(parentDir, path);
@@ -461,7 +461,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 	if (m_ImageCount > 0)
 	{
-		m_ImagePaths = new EFK_CHAR*[m_ImageCount];
+		m_ImagePaths = new char16_t*[m_ImageCount];
 		m_pImages = new TextureData*[m_ImageCount];
 
 		for (int i = 0; i < m_ImageCount; i++)
@@ -469,7 +469,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 			int length = 0;
 			binaryReader.Read(length, 0, elementCountMax);
 
-			m_ImagePaths[i] = new EFK_CHAR[length];
+			m_ImagePaths[i] = new char16_t[length];
 			binaryReader.Read(m_ImagePaths[i], length);
 
 			m_pImages[i] = nullptr;
@@ -483,7 +483,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 		if (m_normalImageCount > 0)
 		{
-			m_normalImagePaths = new EFK_CHAR*[m_normalImageCount];
+			m_normalImagePaths = new char16_t*[m_normalImageCount];
 			m_normalImages = new TextureData*[m_normalImageCount];
 
 			for (int i = 0; i < m_normalImageCount; i++)
@@ -491,7 +491,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				m_normalImagePaths[i] = new EFK_CHAR[length];
+				m_normalImagePaths[i] = new char16_t[length];
 				binaryReader.Read(m_normalImagePaths[i], length);
 
 				m_normalImages[i] = nullptr;
@@ -503,7 +503,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 		if (m_distortionImageCount > 0)
 		{
-			m_distortionImagePaths = new EFK_CHAR*[m_distortionImageCount];
+			m_distortionImagePaths = new char16_t*[m_distortionImageCount];
 			m_distortionImages = new TextureData*[m_distortionImageCount];
 
 			for (int i = 0; i < m_distortionImageCount; i++)
@@ -511,7 +511,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				m_distortionImagePaths[i] = new EFK_CHAR[length];
+				m_distortionImagePaths[i] = new char16_t[length];
 				binaryReader.Read(m_distortionImagePaths[i], length);
 
 				m_distortionImages[i] = nullptr;
@@ -526,7 +526,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 		if (m_WaveCount > 0)
 		{
-			m_WavePaths = new EFK_CHAR*[m_WaveCount];
+			m_WavePaths = new char16_t*[m_WaveCount];
 			m_pWaves = new void*[m_WaveCount];
 
 			for (int i = 0; i < m_WaveCount; i++)
@@ -534,7 +534,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				m_WavePaths[i] = new EFK_CHAR[length];
+				m_WavePaths[i] = new char16_t[length];
 				binaryReader.Read(m_WavePaths[i], length);
 
 				m_pWaves[i] = nullptr;
@@ -558,7 +558,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				modelPaths_[i] = new EFK_CHAR[length];
+				modelPaths_[i] = new char16_t[length];
 				binaryReader.Read(modelPaths_[i], length);
 
 				models_[i] = nullptr;
@@ -573,7 +573,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 		if (materialCount_ > 0)
 		{
-			materialPaths_ = new EFK_CHAR*[materialCount_];
+			materialPaths_ = new char16_t*[materialCount_];
 			materials_ = new MaterialData*[materialCount_];
 
 			for (int i = 0; i < materialCount_; i++)
@@ -581,7 +581,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				materialPaths_[i] = new EFK_CHAR[length];
+				materialPaths_[i] = new char16_t[length];
 				binaryReader.Read(materialPaths_[i], length);
 
 				materials_[i] = nullptr;
@@ -639,7 +639,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 
 		if (curveCount_ > 0)
 		{
-			curvePaths_ = new EFK_CHAR*[curveCount_];
+			curvePaths_ = new char16_t*[curveCount_];
 			curves_ = new void*[curveCount_];
 
 			for (int i = 0; i < curveCount_; i++)
@@ -647,7 +647,7 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 				int length = 0;
 				binaryReader.Read(length, 0, elementCountMax);
 
-				curvePaths_[i] = new EFK_CHAR[length];
+				curvePaths_[i] = new char16_t[length];
 				binaryReader.Read(curvePaths_[i], length);
 
 				curves_[i] = nullptr;
@@ -771,7 +771,7 @@ void EffectImplemented::ResetReloadingBackup()
 	reloadingBackup.reset();
 }
 
-Effect* EffectImplemented::Create(Manager* pManager, void* pData, int size, float magnification, const EFK_CHAR* materialPath)
+Effect* EffectImplemented::Create(Manager* pManager, void* pData, int size, float magnification, const char16_t* materialPath)
 {
 	if (pData == NULL || size == 0)
 		return NULL;
@@ -788,7 +788,7 @@ Effect* EffectImplemented::Create(Manager* pManager, void* pData, int size, floa
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-Effect* Effect::Create(Setting* setting, void* data, int32_t size, float magnification, const EFK_CHAR* materialPath)
+Effect* Effect::Create(Setting* setting, void* data, int32_t size, float magnification, const char16_t* materialPath)
 {
 	return EffectImplemented::Create(setting, data, size, magnification, materialPath);
 }
@@ -796,7 +796,7 @@ Effect* Effect::Create(Setting* setting, void* data, int32_t size, float magnifi
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-Effect* Effect::Create(Setting* setting, const EFK_CHAR* path, float magnification, const EFK_CHAR* materialPath)
+Effect* Effect::Create(Setting* setting, const char16_t* path, float magnification, const char16_t* materialPath)
 {
 	if (setting == NULL)
 		return NULL;
@@ -811,7 +811,7 @@ Effect* Effect::Create(Setting* setting, const EFK_CHAR* path, float magnificati
 	if (!eLoader->Load(path, data, size))
 		return NULL;
 
-	EFK_CHAR parentDir[512];
+	char16_t parentDir[512];
 	if (materialPath == NULL)
 	{
 		GetParentDir(parentDir, path);
@@ -830,7 +830,7 @@ Effect* Effect::Create(Setting* setting, const EFK_CHAR* path, float magnificati
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-Effect* EffectImplemented::Create(Setting* setting, void* pData, int size, float magnification, const EFK_CHAR* materialPath)
+Effect* EffectImplemented::Create(Setting* setting, void* pData, int size, float magnification, const char16_t* materialPath)
 {
 	if (pData == NULL || size == 0)
 		return NULL;
@@ -934,7 +934,7 @@ float EffectImplemented::GetMaginification() const
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-bool EffectImplemented::Load(void* pData, int size, float mag, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType)
+bool EffectImplemented::Load(void* pData, int size, float mag, const char16_t* materialPath, ReloadingThreadType reloadingThreadType)
 {
 	ES_SAFE_RELEASE(factory);
 
@@ -1138,7 +1138,7 @@ int32_t EffectImplemented::GetColorImageCount() const
 	return m_ImageCount;
 }
 
-const EFK_CHAR* EffectImplemented::GetColorImagePath(int n) const
+const char16_t* EffectImplemented::GetColorImagePath(int n) const
 {
 	return m_ImagePaths[n];
 }
@@ -1164,7 +1164,7 @@ int32_t EffectImplemented::GetNormalImageCount() const
 	return m_normalImageCount;
 }
 
-const EFK_CHAR* EffectImplemented::GetNormalImagePath(int n) const
+const char16_t* EffectImplemented::GetNormalImagePath(int n) const
 {
 	return m_normalImagePaths[n];
 }
@@ -1190,7 +1190,7 @@ int32_t EffectImplemented::GetDistortionImageCount() const
 	return m_distortionImageCount;
 }
 
-const EFK_CHAR* EffectImplemented::GetDistortionImagePath(int n) const
+const char16_t* EffectImplemented::GetDistortionImagePath(int n) const
 {
 	return m_distortionImagePaths[n];
 }
@@ -1205,7 +1205,7 @@ int32_t EffectImplemented::GetWaveCount() const
 	return m_WaveCount;
 }
 
-const EFK_CHAR* EffectImplemented::GetWavePath(int n) const
+const char16_t* EffectImplemented::GetWavePath(int n) const
 {
 	return m_WavePaths[n];
 }
@@ -1225,7 +1225,7 @@ int32_t EffectImplemented::GetModelCount() const
 	return static_cast<int32_t>(models_.size());
 }
 
-const EFK_CHAR* EffectImplemented::GetModelPath(int n) const
+const char16_t* EffectImplemented::GetModelPath(int n) const
 {
 	return modelPaths_[n];
 }
@@ -1245,7 +1245,7 @@ int32_t EffectImplemented::GetMaterialCount() const
 	return materialCount_;
 }
 
-const EFK_CHAR* EffectImplemented::GetMaterialPath(int n) const
+const char16_t* EffectImplemented::GetMaterialPath(int n) const
 {
 	return materialPaths_[n];
 }
@@ -1260,7 +1260,7 @@ int32_t EffectImplemented::GetCurveCount() const
 	return curveCount_;
 }
 
-const EFK_CHAR* EffectImplemented::GetCurvePath(int n) const
+const char16_t* EffectImplemented::GetCurvePath(int n) const
 {
 	return curvePaths_[n];
 }
@@ -1380,7 +1380,7 @@ void EffectImplemented::SetCurve(int32_t index, void* data)
 	curves_[index] = data;
 }
 
-bool EffectImplemented::Reload(void* data, int32_t size, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType)
+bool EffectImplemented::Reload(void* data, int32_t size, const char16_t* materialPath, ReloadingThreadType reloadingThreadType)
 {
 	if (m_pManager == NULL)
 		return false;
@@ -1394,7 +1394,7 @@ bool EffectImplemented::Reload(void* data, int32_t size, const EFK_CHAR* materia
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-bool EffectImplemented::Reload(const EFK_CHAR* path, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType)
+bool EffectImplemented::Reload(const char16_t* path, const char16_t* materialPath, ReloadingThreadType reloadingThreadType)
 {
 	if (m_pManager == NULL)
 		return false;
@@ -1412,13 +1412,13 @@ bool EffectImplemented::Reload(Manager** managers,
 							   int32_t managersCount,
 							   void* data,
 							   int32_t size,
-							   const EFK_CHAR* materialPath,
+							   const char16_t* materialPath,
 							   ReloadingThreadType reloadingThreadType)
 {
 	if (!factory->OnCheckIsReloadSupported())
 		return false;
 
-	const EFK_CHAR* matPath = materialPath != NULL ? materialPath : m_materialPath.c_str();
+	const char16_t* matPath = materialPath != NULL ? materialPath : m_materialPath.c_str();
 
 	for (int32_t i = 0; i < managersCount; i++)
 	{
@@ -1467,7 +1467,7 @@ bool EffectImplemented::Reload(Manager** managers,
 //
 //----------------------------------------------------------------------------------
 bool EffectImplemented::Reload(
-	Manager** managers, int32_t managersCount, const EFK_CHAR* path, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType)
+	Manager** managers, int32_t managersCount, const char16_t* path, const char16_t* materialPath, ReloadingThreadType reloadingThreadType)
 {
 	if (!factory->OnCheckIsReloadSupported())
 		return false;
@@ -1484,7 +1484,7 @@ bool EffectImplemented::Reload(
 	if (!eLoader->Load(path, data, size))
 		return false;
 
-	EFK_CHAR parentDir[512];
+	char16_t parentDir[512];
 	if (materialPath == NULL)
 	{
 		GetParentDir(parentDir, path);
@@ -1520,11 +1520,11 @@ bool EffectImplemented::Reload(
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-void EffectImplemented::ReloadResources(const void* data, int32_t size, const EFK_CHAR* materialPath)
+void EffectImplemented::ReloadResources(const void* data, int32_t size, const char16_t* materialPath)
 {
 	UnloadResources();
 
-	const EFK_CHAR* matPath = materialPath != NULL ? materialPath : m_materialPath.c_str();
+	const char16_t* matPath = materialPath != NULL ? materialPath : m_materialPath.c_str();
 
 	Setting* loader = GetSetting();
 
@@ -1535,7 +1535,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < m_ImageCount; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_ImagePaths[ind]);
 
 			TextureData* value = nullptr;
@@ -1547,7 +1547,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < m_normalImageCount; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_normalImagePaths[ind]);
 
 			TextureData* value = nullptr;
@@ -1559,7 +1559,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < m_distortionImageCount; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_distortionImagePaths[ind]);
 
 			TextureData* value = nullptr;
@@ -1571,7 +1571,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < m_WaveCount; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_WavePaths[ind]);
 
 			void* value = nullptr;
@@ -1583,7 +1583,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (size_t ind = 0; ind < models_.size(); ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, modelPaths_[ind]);
 
 			Model* value = nullptr;
@@ -1595,7 +1595,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < materialCount_; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, materialPaths_[ind]);
 
 			MaterialData* value = nullptr;
@@ -1607,7 +1607,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 
 		for (int32_t ind = 0; ind < curveCount_; ind++)
 		{
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, curvePaths_[ind]);
 
 			void* value = nullptr;
@@ -1623,7 +1623,7 @@ void EffectImplemented::ReloadResources(const void* data, int32_t size, const EF
 	factory->OnLoadingResource(this, data, size, matPath);
 }
 
-void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
+void EffectImplemented::UnloadResources(const char16_t* materialPath)
 {
 	Setting* loader = GetSetting();
 
@@ -1635,14 +1635,14 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			reloadingBackup = std::unique_ptr<EffectReloadingBackup>(new EffectReloadingBackup());
 		}
 
-		const EFK_CHAR* matPath = materialPath != nullptr ? materialPath : m_materialPath.c_str();
+		const char16_t* matPath = materialPath != nullptr ? materialPath : m_materialPath.c_str();
 
 		for (int32_t ind = 0; ind < m_ImageCount; ind++)
 		{
 			if (m_pImages[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_ImagePaths[ind]);
 			reloadingBackup->images.Push(fullPath, m_pImages[ind]);
 		}
@@ -1652,7 +1652,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (m_normalImages[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_normalImagePaths[ind]);
 			reloadingBackup->normalImages.Push(fullPath, m_normalImages[ind]);
 		}
@@ -1662,7 +1662,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (m_distortionImagePaths[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_distortionImagePaths[ind]);
 			reloadingBackup->distortionImages.Push(fullPath, m_distortionImages[ind]);
 		}
@@ -1672,7 +1672,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (m_pWaves[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, m_WavePaths[ind]);
 			reloadingBackup->sounds.Push(fullPath, m_pWaves[ind]);
 		}
@@ -1682,7 +1682,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (models_[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, modelPaths_[ind]);
 			reloadingBackup->models.Push(fullPath, models_[ind]);
 		}
@@ -1692,7 +1692,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (materials_[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, materialPaths_[ind]);
 			reloadingBackup->materials.Push(fullPath, materials_[ind]);
 		}
@@ -1702,7 +1702,7 @@ void EffectImplemented::UnloadResources(const EFK_CHAR* materialPath)
 			if (curves_[ind] == nullptr)
 				continue;
 
-			EFK_CHAR fullPath[512];
+			char16_t fullPath[512];
 			PathCombine(fullPath, matPath, curvePaths_[ind]);
 			reloadingBackup->curves.Push(fullPath, curves_[ind]);
 		}

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.h
@@ -119,7 +119,7 @@ public:
 	\~English load body data(parameters of effect) from a binary
 	\~Japanese	バイナリから本体(エフェクトのパラメーター)を読み込む。
 	*/
-	bool LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath);
+	bool LoadBody(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath);
 
 	/**
 	@brief
@@ -190,14 +190,14 @@ public:
 		\~English this method is called when load a effect from binary
 		\~Japanese	バイナリからエフェクトを読み込む時に、このメソッドが呼ばれる。
 	*/
-	virtual bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath);
+	virtual bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath);
 
 	/**
 		@brief
 		\~English this method is called when load resources
 		\~Japanese	リソースを読み込む時に、このメソッドが呼ばれる。
 	*/
-	virtual void OnLoadingResource(Effect* effect, const void* data, int32_t size, const EFK_CHAR* materialPath);
+	virtual void OnLoadingResource(Effect* effect, const void* data, int32_t size, const char16_t* materialPath);
 
 	/**
 	@brief
@@ -244,7 +244,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Manager* manager, void* data, int32_t size, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Manager* manager, void* data, int32_t size, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 		@brief	エフェクトを生成する。
@@ -254,7 +254,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Manager* manager, const EFK_CHAR* path, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Manager* manager, const char16_t* path, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 	@brief	エフェクトを生成する。
@@ -265,7 +265,7 @@ public:
 	@param	materialPath	[in]	素材ロード時の基準パス
 	@return	エフェクト。失敗した場合はNULLを返す。
 */
-	static Effect* Create(Setting* setting, void* data, int32_t size, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Setting* setting, void* data, int32_t size, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 		@brief	エフェクトを生成する。
@@ -275,7 +275,7 @@ public:
 		@param	materialPath	[in]	素材ロード時の基準パス
 		@return	エフェクト。失敗した場合はNULLを返す。
 	*/
-	static Effect* Create(Setting* setting, const EFK_CHAR* path, float magnification = 1.0f, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Setting* setting, const char16_t* path, float magnification = 1.0f, const char16_t* materialPath = NULL);
 
 	/**
 	@brief	標準のエフェクト読込インスタンスを生成する。
@@ -336,7 +336,7 @@ public:
 	@brief	\~English	Get a color image's path
 	\~Japanese	色画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetColorImagePath(int n) const = 0;
+	virtual const char16_t* GetColorImagePath(int n) const = 0;
 
 	/**
 	@brief	格納されている法線画像のポインタを取得する。
@@ -354,7 +354,7 @@ public:
 	@brief	\~English	Get a normal image's path
 	\~Japanese	法線画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetNormalImagePath(int n) const = 0;
+	virtual const char16_t* GetNormalImagePath(int n) const = 0;
 
 	/**
 	@brief	格納されている歪み画像のポインタを取得する。
@@ -372,7 +372,7 @@ public:
 	@brief	\~English	Get a distortion image's path
 	\~Japanese	歪み画像のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetDistortionImagePath(int n) const = 0;
+	virtual const char16_t* GetDistortionImagePath(int n) const = 0;
 
 	/**
 		@brief	格納されている音波形のポインタを取得する。
@@ -388,7 +388,7 @@ public:
 	@brief	\~English	Get a wave's path
 	\~Japanese	音波形のパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetWavePath(int n) const = 0;
+	virtual const char16_t* GetWavePath(int n) const = 0;
 
 	/**
 		@brief	格納されているモデルのポインタを取得する。
@@ -404,7 +404,7 @@ public:
 	@brief	\~English	Get a model's path
 	\~Japanese	モデルのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetModelPath(int n) const = 0;
+	virtual const char16_t* GetModelPath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a material's pointer
@@ -422,7 +422,7 @@ public:
 	@brief	\~English	Get a material's path
 	\~Japanese	マテリアルのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetMaterialPath(int n) const = 0;
+	virtual const char16_t* GetMaterialPath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a curve's pointer
@@ -440,7 +440,7 @@ public:
 	@brief	\~English	Get a curve's path
 	\~Japanese	カーブのパスを取得する。
 	*/
-	virtual const EFK_CHAR* GetCurvePath(int n) const = 0;
+	virtual const char16_t* GetCurvePath(int n) const = 0;
 
 	/**
 	@brief	\~English	Get a procedual model's pointer
@@ -523,7 +523,7 @@ public:
 	*/
 	virtual bool Reload(void* data,
 						int32_t size,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -548,8 +548,8 @@ public:
 		\~Japanese
 		もし、reloadingThreadType が RenderThreadの場合、新規のリソースは読み込まれず、古いリソースは破棄されない。
 	*/
-	virtual bool Reload(const EFK_CHAR* path,
-						const EFK_CHAR* materialPath = nullptr,
+	virtual bool Reload(const char16_t* path,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -589,7 +589,7 @@ public:
 						int32_t managersCount,
 						void* data,
 						int32_t size,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
@@ -624,14 +624,14 @@ public:
 	*/
 	virtual bool Reload(Manager** managers,
 						int32_t managersCount,
-						const EFK_CHAR* path,
-						const EFK_CHAR* materialPath = nullptr,
+						const char16_t* path,
+						const char16_t* materialPath = nullptr,
 						ReloadingThreadType reloadingThreadType = ReloadingThreadType::Main) = 0;
 
 	/**
 		@brief	画像等リソースの再読み込みを行う。
 	*/
-	virtual void ReloadResources(const void* data = nullptr, int32_t size = 0, const EFK_CHAR* materialPath = nullptr) = 0;
+	virtual void ReloadResources(const void* data = nullptr, int32_t size = 0, const char16_t* materialPath = nullptr) = 0;
 
 	/**
 		@brief	画像等リソースの破棄を行う。

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectImplemented.h
@@ -118,37 +118,37 @@ protected:
 	int m_version;
 
 	int m_ImageCount;
-	EFK_CHAR** m_ImagePaths;
+	char16_t** m_ImagePaths;
 	TextureData** m_pImages;
 
 	int m_normalImageCount;
-	EFK_CHAR** m_normalImagePaths;
+	char16_t** m_normalImagePaths;
 	TextureData** m_normalImages;
 
 	int m_distortionImageCount;
-	EFK_CHAR** m_distortionImagePaths;
+	char16_t** m_distortionImagePaths;
 	TextureData** m_distortionImages;
 
 	int m_WaveCount = 0;
-	EFK_CHAR** m_WavePaths = nullptr;
+	char16_t** m_WavePaths = nullptr;
 	void** m_pWaves = nullptr;
 
 	CustomVector<Model*> models_;
-	CustomVector<EFK_CHAR*> modelPaths_;
+	CustomVector<char16_t*> modelPaths_;
 
 	CustomVector<Model*> procedualModels_;
 	CustomVector<ProcedualModelParameter> procedualModelParameters_;
 
 	int32_t materialCount_ = 0;
-	EFK_CHAR** materialPaths_ = nullptr;
+	char16_t** materialPaths_ = nullptr;
 	MaterialData** materials_ = nullptr;
 
 	int32_t curveCount_ = 0;
-	EFK_CHAR** curvePaths_ = nullptr;
+	char16_t** curvePaths_ = nullptr;
 	void** curves_ = nullptr;
 
 	std::u16string name_;
-	std::basic_string<EFK_CHAR> m_materialPath;
+	std::basic_string<char16_t> m_materialPath;
 
 	//! dynamic inputs
 	std::array<float, 4> defaultDynamicInputs;
@@ -206,12 +206,12 @@ public:
 	/**
 		@brief	生成
 	*/
-	static Effect* Create(Manager* pManager, void* pData, int size, float magnification, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Manager* pManager, void* pData, int size, float magnification, const char16_t* materialPath = NULL);
 
 	/**
 		@brief	生成
 	*/
-	static Effect* Create(Setting* setting, void* pData, int size, float magnification, const EFK_CHAR* materialPath = NULL);
+	static Effect* Create(Setting* setting, void* pData, int size, float magnification, const char16_t* materialPath = NULL);
 
 	// コンストラクタ
 	EffectImplemented(Manager* pManager, void* pData, int size);
@@ -227,7 +227,7 @@ public:
 
 	float GetMaginification() const override;
 
-	bool Load(void* pData, int size, float mag, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType);
+	bool Load(void* pData, int size, float mag, const char16_t* materialPath, ReloadingThreadType reloadingThreadType);
 
 	/**
 		@breif	何も読み込まれていない状態に戻す
@@ -276,7 +276,7 @@ public:
 
 	int32_t GetColorImageCount() const override;
 
-	const EFK_CHAR* GetColorImagePath(int n) const override;
+	const char16_t* GetColorImagePath(int n) const override;
 
 	/**
 	@brief	格納されている画像のポインタを取得する。
@@ -285,37 +285,37 @@ public:
 
 	int32_t GetNormalImageCount() const override;
 
-	const EFK_CHAR* GetNormalImagePath(int n) const override;
+	const char16_t* GetNormalImagePath(int n) const override;
 
 	TextureData* GetDistortionImage(int n) const override;
 
 	int32_t GetDistortionImageCount() const override;
 
-	const EFK_CHAR* GetDistortionImagePath(int n) const override;
+	const char16_t* GetDistortionImagePath(int n) const override;
 
 	void* GetWave(int n) const override;
 
 	int32_t GetWaveCount() const override;
 
-	const EFK_CHAR* GetWavePath(int n) const override;
+	const char16_t* GetWavePath(int n) const override;
 
 	Model* GetModel(int n) const override;
 
 	int32_t GetModelCount() const override;
 
-	const EFK_CHAR* GetModelPath(int n) const override;
+	const char16_t* GetModelPath(int n) const override;
 
 	MaterialData* GetMaterial(int n) const override;
 
 	int32_t GetMaterialCount() const override;
 
-	const EFK_CHAR* GetMaterialPath(int n) const override;
+	const char16_t* GetMaterialPath(int n) const override;
 
 	void* GetCurve(int n) const override;
 
 	int32_t GetCurveCount() const override;
 
-	const EFK_CHAR* GetCurvePath(int n) const override;
+	const char16_t* GetCurvePath(int n) const override;
 
 	Model* GetProcedualModel(int n) const override;
 
@@ -336,12 +336,12 @@ public:
 	/**
 		@brief	エフェクトのリロードを行う。
 	*/
-	bool Reload(void* data, int32_t size, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType) override;
+	bool Reload(void* data, int32_t size, const char16_t* materialPath, ReloadingThreadType reloadingThreadType) override;
 
 	/**
 		@brief	エフェクトのリロードを行う。
 	*/
-	bool Reload(const EFK_CHAR* path, const EFK_CHAR* materialPath, ReloadingThreadType reloadingThreadType) override;
+	bool Reload(const char16_t* path, const char16_t* materialPath, ReloadingThreadType reloadingThreadType) override;
 
 	/**
 		@brief	エフェクトのリロードを行う。
@@ -350,7 +350,7 @@ public:
 				int32_t managersCount,
 				void* data,
 				int32_t size,
-				const EFK_CHAR* materialPath,
+				const char16_t* materialPath,
 				ReloadingThreadType reloadingThreadType) override;
 
 	/**
@@ -358,16 +358,16 @@ public:
 	*/
 	bool Reload(Manager** managers,
 				int32_t managersCount,
-				const EFK_CHAR* path,
-				const EFK_CHAR* materialPath,
+				const char16_t* path,
+				const char16_t* materialPath,
 				ReloadingThreadType reloadingThreadType) override;
 
 	/**
 		@brief	画像等リソースの再読み込みを行う。
 	*/
-	void ReloadResources(const void* data, int32_t size, const EFK_CHAR* materialPath) override;
+	void ReloadResources(const void* data, int32_t size, const char16_t* materialPath) override;
 
-	void UnloadResources(const EFK_CHAR* materialPath);
+	void UnloadResources(const char16_t* materialPath);
 
 	void UnloadResources() override;
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectLoader.h
@@ -45,7 +45,7 @@ public:
 		エフェクトファイルを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual bool Load(const EFK_CHAR* path, void*& data, int32_t& size) = 0;
+	virtual bool Load(const char16_t* path, void*& data, int32_t& size) = 0;
 
 	/**
 		@brief	エフェクトファイルを破棄する。

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.File.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.File.h
@@ -77,19 +77,19 @@ public:
 	FileInterface() = default;
 	virtual ~FileInterface() = default;
 
-	virtual FileReader* OpenRead(const EFK_CHAR* path) = 0;
+	virtual FileReader* OpenRead(const char16_t* path) = 0;
 
 	/**
 		@brief
 		\~English	try to open a reader. It need not to succeeds in opening it.
 		\~Japanese	リーダーを開くことを試します。成功する必要はありません。
 	*/
-	virtual FileReader* TryOpenRead(const EFK_CHAR* path)
+	virtual FileReader* TryOpenRead(const char16_t* path)
 	{
 		return OpenRead(path);
 	}
 
-	virtual FileWriter* OpenWrite(const EFK_CHAR* path) = 0;
+	virtual FileWriter* OpenWrite(const char16_t* path) = 0;
 };
 
 } // namespace Effekseer

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.MaterialLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.MaterialLoader.h
@@ -40,7 +40,7 @@ public:
 		\~English	a pointer of loaded a material
 		\~Japanese	読み込まれたマテリアルのポインタ
 	*/
-	virtual MaterialData* Load(const EFK_CHAR* path)
+	virtual MaterialData* Load(const char16_t* path)
 	{
 		return nullptr;
 	}

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Server.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Server.cpp
@@ -291,7 +291,7 @@ void ServerImplemented::Stop()
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-void ServerImplemented::Register(const EFK_CHAR* key, Effect* effect)
+void ServerImplemented::Register(const char16_t* key, Effect* effect)
 {
 	if (effect == NULL)
 		return;
@@ -435,7 +435,7 @@ void ServerImplemented::Update(Manager** managers, int32_t managerCount, Reloadi
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-void ServerImplemented::SetMaterialPath(const EFK_CHAR* materialPath)
+void ServerImplemented::SetMaterialPath(const char16_t* materialPath)
 {
 	m_materialPath.clear();
 
@@ -448,7 +448,7 @@ void ServerImplemented::SetMaterialPath(const EFK_CHAR* materialPath)
 	m_materialPath.push_back(0);
 }
 
-void ServerImplemented::Regist(const EFK_CHAR* key, Effect* effect)
+void ServerImplemented::Regist(const char16_t* key, Effect* effect)
 {
 	Register(key, effect);
 }

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Server.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Server.h
@@ -65,7 +65,7 @@ public:
 		\~English	an effect to be edit
 		\~Japanese	編集される対象のエフェクト
 	*/
-	virtual void Register(const EFK_CHAR* key, Effect* effect) = 0;
+	virtual void Register(const char16_t* key, Effect* effect) = 0;
 
 	/**
 		@brief
@@ -97,14 +97,14 @@ public:
 		\~English	Specify root path to load materials
 		\~Japanese	素材のルートパスを設定する。
 	*/
-	virtual void SetMaterialPath(const EFK_CHAR* materialPath) = 0;
+	virtual void SetMaterialPath(const char16_t* materialPath) = 0;
 
 	/**
 		@brief
 		\~English	deprecated
 		\~Japanese	非推奨
 	*/
-	virtual void Regist(const EFK_CHAR* key, Effect* effect) = 0;
+	virtual void Regist(const char16_t* key, Effect* effect) = 0;
 
 	/**
 		@brief

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ServerImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ServerImplemented.h
@@ -67,7 +67,7 @@ private:
 
 	std::map<std::u16string, std::vector<uint8_t>> m_data;
 
-	std::vector<EFK_CHAR> m_materialPath;
+	std::vector<char16_t> m_materialPath;
 
 	void AddClient(InternalClient* client);
 	void RemoveClient(InternalClient* client);
@@ -81,15 +81,15 @@ public:
 
 	void Stop() override;
 
-	void Register(const EFK_CHAR* key, Effect* effect) override;
+	void Register(const char16_t* key, Effect* effect) override;
 
 	void Unregister(Effect* effect) override;
 
 	void Update(Manager** managers, int32_t managerCount, ReloadingThreadType reloadingThreadType) override;
 
-	void SetMaterialPath(const EFK_CHAR* materialPath) override;
+	void SetMaterialPath(const char16_t* materialPath) override;
 
-	void Regist(const EFK_CHAR* key, Effect* effect) override;
+	void Regist(const char16_t* key, Effect* effect) override;
 
 	void Unregist(Effect* effect) override;
 };

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.SoundLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.SoundLoader.h
@@ -43,7 +43,7 @@ public:
 		サウンドを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual void* Load(const EFK_CHAR* path)
+	virtual void* Load(const char16_t* path)
 	{
 		return NULL;
 	}

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.TextureLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.TextureLoader.h
@@ -44,7 +44,7 @@ public:
 		テクスチャを読み込む。
 		::Effekseer::Effect::Create実行時に使用される。
 	*/
-	virtual TextureData* Load(const EFK_CHAR* path, TextureType textureType)
+	virtual TextureData* Load(const char16_t* path, TextureType textureType)
 	{
 		return nullptr;
 	}

--- a/Dev/Cpp/Effekseer/Effekseer/IO/Effekseer.EfkEfcFactory.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/IO/Effekseer.EfkEfcFactory.cpp
@@ -4,7 +4,7 @@
 namespace Effekseer
 {
 
-bool EfkEfcFactory::OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath)
+bool EfkEfcFactory::OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath)
 {
 	BinaryReader<true> binaryReader(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data)), size);
 

--- a/Dev/Cpp/Effekseer/Effekseer/IO/Effekseer.EfkEfcFactory.h
+++ b/Dev/Cpp/Effekseer/Effekseer/IO/Effekseer.EfkEfcFactory.h
@@ -15,7 +15,7 @@ class EfkEfcFactory : public EffectFactory
 {
 private:
 public:
-	bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const EFK_CHAR* materialPath) override;
+	bool OnLoading(Effect* effect, const void* data, int32_t size, float magnification, const char16_t* materialPath) override;
 
 	bool OnCheckIsBinarySupported(const void* data, int32_t size) override;
 };

--- a/Dev/Cpp/Effekseer/Effekseer/Model/ModelLoader.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Model/ModelLoader.cpp
@@ -3,7 +3,7 @@
 namespace Effekseer
 {
 
-Model* ModelLoader::Load(const EFK_CHAR* path)
+Model* ModelLoader::Load(const char16_t* path)
 {
 	return nullptr;
 }

--- a/Dev/Cpp/Effekseer/Effekseer/Model/ModelLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Model/ModelLoader.h
@@ -29,7 +29,7 @@ public:
 	\~English a pointer of loaded a model
 	\~Japanese 読み込まれたモデルのポインタ
 	*/
-	virtual Model* Load(const EFK_CHAR* path);
+	virtual Model* Load(const char16_t* path);
 
 	/**
 		@brief

--- a/Dev/Cpp/EffekseerRendererCommon/TextureLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererCommon/TextureLoader.cpp
@@ -24,7 +24,7 @@ TextureLoader::~TextureLoader()
 	ES_SAFE_RELEASE(graphicsDevice_);
 }
 
-Effekseer::TextureData* TextureLoader::Load(const EFK_CHAR* path, ::Effekseer::TextureType textureType)
+Effekseer::TextureData* TextureLoader::Load(const char16_t* path, ::Effekseer::TextureType textureType)
 {
 	std::unique_ptr<::Effekseer::FileReader> reader(m_fileInterface->OpenRead(path));
 

--- a/Dev/Cpp/EffekseerRendererCommon/TextureLoader.h
+++ b/Dev/Cpp/EffekseerRendererCommon/TextureLoader.h
@@ -32,7 +32,7 @@ public:
 	virtual ~TextureLoader();
 
 public:
-	Effekseer::TextureData* Load(const EFK_CHAR* path, ::Effekseer::TextureType textureType) override;
+	Effekseer::TextureData* Load(const char16_t* path, ::Effekseer::TextureType textureType) override;
 
 	Effekseer::TextureData* Load(const void* data, int32_t size, Effekseer::TextureType textureType, bool isMipMapEnabled) override;
 

--- a/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.MaterialLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.MaterialLoader.cpp
@@ -29,7 +29,7 @@ MaterialLoader ::~MaterialLoader()
 	ES_SAFE_RELEASE(renderer_);
 }
 
-::Effekseer::MaterialData* MaterialLoader::Load(const EFK_CHAR* path)
+::Effekseer::MaterialData* MaterialLoader::Load(const char16_t* path)
 {
 	// code file
 	{

--- a/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.MaterialLoader.h
+++ b/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.MaterialLoader.h
@@ -28,7 +28,7 @@ public:
 	MaterialLoader(Renderer* renderer, ::Effekseer::FileInterface* fileInterface);
 	virtual ~MaterialLoader();
 
-	::Effekseer::MaterialData* Load(const EFK_CHAR* path) override;
+	::Effekseer::MaterialData* Load(const char16_t* path) override;
 
 	::Effekseer::MaterialData* Load(const void* data, int32_t size, Effekseer::MaterialFileType fileType) override;
 

--- a/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.ModelLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.ModelLoader.cpp
@@ -40,7 +40,7 @@ ModelLoader::~ModelLoader()
 	ES_SAFE_RELEASE(graphicsDevice_);
 }
 
-Effekseer::Model* ModelLoader::Load(const EFK_CHAR* path)
+Effekseer::Model* ModelLoader::Load(const char16_t* path)
 {
 	std::unique_ptr<::Effekseer::FileReader> reader(m_fileInterface->OpenRead(path));
 	if (reader.get() == NULL)

--- a/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.ModelLoader.h
+++ b/Dev/Cpp/EffekseerRendererDX11/EffekseerRenderer/EffekseerRendererDX11.ModelLoader.h
@@ -32,7 +32,7 @@ public:
 	virtual ~ModelLoader();
 
 public:
-	Effekseer::Model* Load(const EFK_CHAR* path) override;
+	Effekseer::Model* Load(const char16_t* path) override;
 
 	Effekseer::Model* Load(const void* data, int32_t size) override;
 

--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.MaterialLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.MaterialLoader.cpp
@@ -31,7 +31,7 @@ MaterialLoader ::~MaterialLoader()
 	ES_SAFE_RELEASE(renderer_);
 }
 
-::Effekseer::MaterialData* MaterialLoader::Load(const EFK_CHAR* path)
+::Effekseer::MaterialData* MaterialLoader::Load(const char16_t* path)
 {
 	// code file
 	{

--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.MaterialLoader.h
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.MaterialLoader.h
@@ -28,7 +28,7 @@ public:
 	MaterialLoader(Renderer* renderer, ::Effekseer::FileInterface* fileInterface);
 	virtual ~MaterialLoader();
 
-	::Effekseer::MaterialData* Load(const EFK_CHAR* path) override;
+	::Effekseer::MaterialData* Load(const char16_t* path) override;
 
 	::Effekseer::MaterialData* Load(const void* data, int32_t size, Effekseer::MaterialFileType fileType) override;
 

--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.ModelLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.ModelLoader.cpp
@@ -57,7 +57,7 @@ ModelLoader::~ModelLoader()
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-Effekseer::Model* ModelLoader::Load(const EFK_CHAR* path)
+Effekseer::Model* ModelLoader::Load(const char16_t* path)
 {
 	std::unique_ptr<::Effekseer::FileReader> reader(m_fileInterface->OpenRead(path));
 

--- a/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.ModelLoader.h
+++ b/Dev/Cpp/EffekseerRendererDX9/EffekseerRenderer/EffekseerRendererDX9.ModelLoader.h
@@ -35,7 +35,7 @@ public:
 	virtual ~ModelLoader();
 
 public:
-	Effekseer::Model* Load(const EFK_CHAR* path) override;
+	Effekseer::Model* Load(const char16_t* path) override;
 
 	Effekseer::Model* Load(const void* data, int32_t size) override;
 

--- a/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.MaterialLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.MaterialLoader.cpp
@@ -352,7 +352,7 @@ MaterialLoader ::~MaterialLoader()
 	ES_SAFE_RELEASE(graphicsDevice_);
 }
 
-::Effekseer::MaterialData* MaterialLoader::Load(const EFK_CHAR* path)
+::Effekseer::MaterialData* MaterialLoader::Load(const char16_t* path)
 {
 	// code file
 	if (canLoadFromCache_)

--- a/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.MaterialLoader.h
+++ b/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.MaterialLoader.h
@@ -30,7 +30,7 @@ public:
 	MaterialLoader(GraphicsDevice* graphicsDevice, ::Effekseer::FileInterface* fileInterface, bool canLoadFromCache = true);
 	virtual ~MaterialLoader();
 
-	::Effekseer::MaterialData* Load(const EFK_CHAR* path) override;
+	::Effekseer::MaterialData* Load(const char16_t* path) override;
 
 	::Effekseer::MaterialData* Load(const void* data, int32_t size, Effekseer::MaterialFileType fileType) override;
 

--- a/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.ModelLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.ModelLoader.cpp
@@ -33,7 +33,7 @@ ModelLoader::~ModelLoader()
 	ES_SAFE_RELEASE(graphicsDevice_);
 }
 
-Effekseer::Model* ModelLoader::Load(const EFK_CHAR* path)
+Effekseer::Model* ModelLoader::Load(const char16_t* path)
 {
 	std::unique_ptr<Effekseer::FileReader> reader(m_fileInterface->OpenRead(path));
 

--- a/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.ModelLoader.h
+++ b/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.ModelLoader.h
@@ -29,7 +29,7 @@ public:
 	virtual ~ModelLoader();
 
 public:
-	Effekseer::Model* Load(const EFK_CHAR* path) override;
+	Effekseer::Model* Load(const char16_t* path) override;
 
 	Effekseer::Model* Load(const void* data, int32_t size) override;
 

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.MaterialLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.MaterialLoader.cpp
@@ -63,7 +63,7 @@ MaterialLoader ::~MaterialLoader()
 	ES_SAFE_RELEASE(graphicsDevice_);
 }
 
-::Effekseer::MaterialData* MaterialLoader::Load(const EFK_CHAR* path)
+::Effekseer::MaterialData* MaterialLoader::Load(const char16_t* path)
 {
 	// code file
 	{

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.MaterialLoader.h
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.MaterialLoader.h
@@ -40,7 +40,7 @@ public:
 				   ::Effekseer::MaterialCompiler* materialCompiler);
 	virtual ~MaterialLoader();
 
-	::Effekseer::MaterialData* Load(const EFK_CHAR* path) override;
+	::Effekseer::MaterialData* Load(const char16_t* path) override;
 
 	::Effekseer::MaterialData* Load(const void* data, int32_t size, Effekseer::MaterialFileType fileType) override;
 

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.ModelLoader.cpp
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.ModelLoader.cpp
@@ -24,7 +24,7 @@ ModelLoader::~ModelLoader()
 	LLGI::SafeRelease(graphicsDevice_);
 }
 
-Effekseer::Model* ModelLoader::Load(const EFK_CHAR* path)
+Effekseer::Model* ModelLoader::Load(const char16_t* path)
 {
 	std::unique_ptr<::Effekseer::FileReader> reader(m_fileInterface->OpenRead(path));
 	if (reader.get() == NULL)

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.ModelLoader.h
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI.ModelLoader.h
@@ -20,7 +20,7 @@ public:
 	virtual ~ModelLoader();
 
 public:
-	Effekseer::Model* Load(const EFK_CHAR* path) override;
+	Effekseer::Model* Load(const char16_t* path) override;
 
 	Effekseer::Model* Load(const void* data, int32_t size) override;
 

--- a/Dev/Cpp/EffekseerSoundDSound/EffekseerSound/EffekseerSoundDSound.SoundLoader.cpp
+++ b/Dev/Cpp/EffekseerSoundDSound/EffekseerSound/EffekseerSoundDSound.SoundLoader.cpp
@@ -220,7 +220,7 @@ void* SoundLoader::Load(::Effekseer::FileReader* reader)
 	return soundData;
 }
 
-void* SoundLoader::Load(const EFK_CHAR* path)
+void* SoundLoader::Load(const char16_t* path)
 {
 	assert(path != NULL);
 

--- a/Dev/Cpp/EffekseerSoundOSMixer/EffekseerSound/EffekseerSoundOSMixer.SoundLoader.cpp
+++ b/Dev/Cpp/EffekseerSoundOSMixer/EffekseerSound/EffekseerSoundOSMixer.SoundLoader.cpp
@@ -36,7 +36,7 @@ SoundLoader::~SoundLoader()
 //----------------------------------------------------------------------------------
 //
 //----------------------------------------------------------------------------------
-void* SoundLoader::Load(const EFK_CHAR* path)
+void* SoundLoader::Load(const char16_t* path)
 {
 	assert(path != NULL);
 

--- a/Dev/Cpp/EffekseerSoundXAudio2/EffekseerSound/EffekseerSoundXAudio2.SoundLoader.cpp
+++ b/Dev/Cpp/EffekseerSoundXAudio2/EffekseerSound/EffekseerSoundXAudio2.SoundLoader.cpp
@@ -189,7 +189,7 @@ void* SoundLoader::Load(::Effekseer::FileReader* reader)
 	return soundData;
 }
 
-void* SoundLoader::Load(const EFK_CHAR* path)
+void* SoundLoader::Load(const char16_t* path)
 {
 	assert(path != NULL);
 

--- a/Dev/Cpp/Viewer/dll.cpp
+++ b/Dev/Cpp/Viewer/dll.cpp
@@ -244,7 +244,7 @@ Native::TextureLoader::~TextureLoader()
 	ES_SAFE_DELETE(m_originalTextureLoader);
 }
 
-Effekseer::TextureData* Native::TextureLoader::Load(const EFK_CHAR* path, ::Effekseer::TextureType textureType)
+Effekseer::TextureData* Native::TextureLoader::Load(const char16_t* path, ::Effekseer::TextureType textureType)
 {
 	char16_t dst[260];
 	Combine(RootPath.c_str(), (const char16_t*)path, dst, 260);
@@ -257,7 +257,7 @@ Effekseer::TextureData* Native::TextureLoader::Load(const EFK_CHAR* path, ::Effe
 	}
 	else
 	{
-		auto t = m_originalTextureLoader->Load((EFK_CHAR*)dst, textureType);
+		auto t = m_originalTextureLoader->Load((char16_t*)dst, textureType);
 
 		if (t != nullptr)
 		{
@@ -284,9 +284,9 @@ Native::SoundLoader::~SoundLoader()
 {
 }
 
-void* Native::SoundLoader::Load(const EFK_CHAR* path)
+void* Native::SoundLoader::Load(const char16_t* path)
 {
-	EFK_CHAR dst[260];
+	char16_t dst[260];
 	Combine(RootPath.c_str(), (const char16_t*)path, (char16_t*)dst, 260);
 
 	return m_loader->Load(dst);
@@ -306,7 +306,7 @@ Native::ModelLoader::~ModelLoader()
 {
 }
 
-Effekseer::Model* Native::ModelLoader::Load(const EFK_CHAR* path)
+Effekseer::Model* Native::ModelLoader::Load(const char16_t* path)
 {
 	char16_t dst[260];
 	Combine(RootPath.c_str(), (const char16_t*)path, dst, 260);
@@ -323,7 +323,7 @@ Effekseer::Model* Native::ModelLoader::Load(const EFK_CHAR* path)
 		if (g_deviceType == efk::DeviceType::OpenGL)
 		{
 			auto loader = ::EffekseerRendererGL::CreateModelLoader();
-			auto m = (Effekseer::Model*)loader->Load((const EFK_CHAR*)dst);
+			auto m = (Effekseer::Model*)loader->Load((const char16_t*)dst);
 
 			if (m != nullptr)
 			{
@@ -339,7 +339,7 @@ Effekseer::Model* Native::ModelLoader::Load(const EFK_CHAR* path)
 		{
 			auto g = static_cast<efk::GraphicsDX11*>(graphics_);
 			auto loader = ::EffekseerRendererDX11::CreateModelLoader(g->GetDevice());
-			auto m = (Effekseer::Model*)loader->Load((const EFK_CHAR*)dst);
+			auto m = (Effekseer::Model*)loader->Load((const char16_t*)dst);
 
 			if (m != nullptr)
 			{
@@ -380,7 +380,7 @@ Native::MaterialLoader::~MaterialLoader()
 	ES_SAFE_DELETE(loader_);
 }
 
-Effekseer::MaterialData* Native::MaterialLoader::Load(const EFK_CHAR* path)
+Effekseer::MaterialData* Native::MaterialLoader::Load(const char16_t* path)
 {
 	if (loader_ == nullptr)
 	{
@@ -1097,7 +1097,7 @@ bool Native::IsConnectingNetwork()
 
 void Native::SendDataByNetwork(const char16_t* key, void* data, int size, const char16_t* path)
 {
-	g_client->Reload((const EFK_CHAR*)key, data, size);
+	g_client->Reload((const char16_t*)key, data, size);
 }
 
 void Native::SetLightDirection(float x, float y, float z)

--- a/Dev/Cpp/Viewer/dll.h
+++ b/Dev/Cpp/Viewer/dll.h
@@ -130,7 +130,7 @@ private:
 		virtual ~TextureLoader();
 
 	public:
-		Effekseer::TextureData* Load(const EFK_CHAR* path, ::Effekseer::TextureType textureType) override;
+		Effekseer::TextureData* Load(const char16_t* path, ::Effekseer::TextureType textureType) override;
 
 		void Unload(Effekseer::TextureData* data) override;
 
@@ -151,7 +151,7 @@ private:
 		virtual ~SoundLoader();
 
 	public:
-		void* Load(const EFK_CHAR* path);
+		void* Load(const char16_t* path);
 
 		void Unload(void* data);
 
@@ -168,7 +168,7 @@ private:
 		virtual ~ModelLoader();
 
 	public:
-		Effekseer::Model* Load(const EFK_CHAR* path);
+		Effekseer::Model* Load(const char16_t* path);
 
 		void Unload(Effekseer::Model* data);
 
@@ -186,7 +186,7 @@ private:
 		virtual ~MaterialLoader();
 
 	public:
-		Effekseer::MaterialData* Load(const EFK_CHAR* path) override;
+		Effekseer::MaterialData* Load(const char16_t* path) override;
 		std::u16string RootPath;
 
 		::Effekseer::MaterialLoader* GetOriginalLoader()


### PR DESCRIPTION
Replaced EFK_CHAR to char16_t.
互換性維持のため`typedef char16_t EFK_CHAR;`は残す。