### PR TITLE
Prevent GTK from changing locale during its initialization on Linux

### DIFF
--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
@@ -25,6 +25,9 @@
 
 #include "../dll.h"
 
+#ifdef __linux__
+	#include <gtk/gtk.h>
+#endif
 namespace ImGui
 {
 static ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs)
@@ -664,6 +667,9 @@ GUIManager::~GUIManager()
 
 bool GUIManager::Initialize(std::shared_ptr<Effekseer::MainWindow> mainWindow, efk::DeviceType deviceType)
 {
+	#ifdef __linux__
+		gtk_disable_setlocale();
+	#endif
 	window = new efk::Window();
 
 	this->deviceType = deviceType;


### PR DESCRIPTION
When initialized in nfd and Boxer, GTK might change the locale as per https://developer.gnome.org/gtk3/stable/gtk3-General.html#gtk-disable-setlocale .
This might cause issues in effekseer (such as change in the decimal separator character) when initialized using a different locale.
This patch disables this behavior by calling `gtk_disable_setlocale()` in `GUIManager::Initialize` when compiled for linux.
