### PR TITLE
Changed culled objects sort order 

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
@@ -2279,7 +2279,7 @@ void ManagerImplemented::CalcCulling(const Matrix44& cameraProjMat, bool isOpenG
 	}
 
 	// sort with handle
-	std::sort(m_culledObjects.begin(), m_culledObjects.end(), [](DrawSet* const& lhs, DrawSet* const& rhs) { return lhs->Self > rhs->Self; });
+	std::sort(m_culledObjects.begin(), m_culledObjects.end(), [](DrawSet* const& lhs, DrawSet* const& rhs) { return lhs->Self < rhs->Self; });
 
 	m_culled = true;
 }


### PR DESCRIPTION
Hello! I have a problem. I use two large effects in same time and place and they draws in wrong order. 
First added (played?) effect are upper then second effect, the right is - second must be upper ("close" to user) 
Why do you use descending order here?