### PR TITLE
moved erasing of stopped effect

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
@@ -222,7 +222,6 @@ void ManagerImplemented::GCDrawSet(bool isRemovingManager)
 
 			if (m_cullingWorld != nullptr && drawset.CullingObjectPointer != nullptr)
 			{
-				m_cullingWorld->RemoveObject(drawset.CullingObjectPointer);
 				Culling3D::SafeRelease(drawset.CullingObjectPointer);
 			}
 
@@ -262,6 +261,11 @@ void ManagerImplemented::GCDrawSet(bool isRemovingManager)
 				{
 					(*it).second.RemovingCallback(this, (*it).first, isRemovingManager);
 				}
+                
+                		if (m_cullingWorld != NULL && (*it).second.CullingObjectPointer != nullptr)
+                		{
+                    			m_cullingWorld->RemoveObject((*it).second.CullingObjectPointer);
+                		}
 
 				m_RemovingDrawSets[0][(*it).first] = (*it).second;
 				m_DrawSets.erase(it++);


### PR DESCRIPTION
Hello, again. New problem with few effects. Run 2 effects, if first effect will end while second is playing, second will blink (become more lighter or smth like this). So the experiment show, that the problem, is in effect object are in culling_world next 2-3 frames. I saved fully delete of object in start place, but it can be wrong