### PR TITLE
Avoid precision loss with GetSRT

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
@@ -848,6 +848,8 @@ void ManagerImplemented::SetMatrix(Handle handle, const Matrix43& mat)
 		if (mat_ != nullptr)
 		{
 			(*mat_) = mat;
+			Vector3D t;
+			mat.GetSRT(drawSet.Scaling, drawSet.Rotation, t);
 			drawSet.CopyMatrixFromInstanceToRoot();
 			drawSet.IsParameterChanged = true;
 		}
@@ -926,14 +928,11 @@ void ManagerImplemented::SetRotation(Handle handle, float x, float y, float z)
 
 		if (mat_ != nullptr)
 		{
-			SIMD::Mat43f r;
-			SIMD::Vec3f s, t;
+			const auto t = mat_->GetTranslation();
 
-			mat_->GetSRT(s, r, t);
+			drawSet.Rotation.RotationZXY(z, x, y);
 
-			r = SIMD::Mat43f::RotationZXY(z, x, y);
-
-			*mat_ = SIMD::Mat43f::SRT(s, r, t);
+			*mat_ = SIMD::Mat43f::SRT(drawSet.Scaling, drawSet.Rotation, t);
 
 			drawSet.CopyMatrixFromInstanceToRoot();
 			drawSet.IsParameterChanged = true;
@@ -951,14 +950,11 @@ void ManagerImplemented::SetRotation(Handle handle, const Vector3D& axis, float 
 
 		if (mat_ != nullptr)
 		{
-			SIMD::Mat43f r;
-			SIMD::Vec3f s, t;
+			const auto t = mat_->GetTranslation();
 
-			mat_->GetSRT(s, r, t);
+			drawSet.Rotation.RotationAxis(axis, angle);
 
-			r = SIMD::Mat43f::RotationAxis(axis, angle);
-
-			*mat_ = SIMD::Mat43f::SRT(s, r, t);
+			*mat_ = SIMD::Mat43f::SRT(drawSet.Scaling, drawSet.Rotation, t);
 
 			drawSet.CopyMatrixFromInstanceToRoot();
 			drawSet.IsParameterChanged = true;
@@ -976,14 +972,11 @@ void ManagerImplemented::SetScale(Handle handle, float x, float y, float z)
 
 		if (mat_ != nullptr)
 		{
-			SIMD::Mat43f r;
-			SIMD::Vec3f s, t;
+			const auto t = mat_->GetTranslation();
 
-			mat_->GetSRT(s, r, t);
+			drawSet.Scaling = { x, y, z };
 
-			s = SIMD::Vec3f(x, y, z);
-
-			*mat_ = SIMD::Mat43f::SRT(s, r, t);
+			*mat_ = SIMD::Mat43f::SRT(drawSet.Scaling, drawSet.Rotation, t);
 
 			drawSet.CopyMatrixFromInstanceToRoot();
 			drawSet.IsParameterChanged = true;

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
@@ -41,6 +41,9 @@ private:
 		bool GoingToStopRoot;
 		EffectInstanceRemovingCallback RemovingCallback;
 
+		Matrix43 Rotation;
+		Vector3D Scaling = { 1.f, 1.f, 1.f };
+
 		SIMD::Mat43f BaseMatrix;
 		SIMD::Mat43f GlobalMatrix;
 
@@ -83,6 +86,7 @@ private:
 			, Speed(1.0f)
 			, Self(-1)
 		{
+			Rotation.Indentity();
 		}
 
 		DrawSet()
@@ -99,6 +103,7 @@ private:
 			, Speed(1.0f)
 			, Self(-1)
 		{
+			Rotation.Indentity();
 		}
 
 		SIMD::Mat43f* GetEnabledGlobalMatrix();


### PR DESCRIPTION
Using SetRotation many times will cause floating precision loss in GetSRT. These floating precision errors will result in the scaling part of the matrix to become distorted after a while.

This is because GetSRT extracts scaling values from the matrix by square roots and this not accurate at all.

So, to prevent this, keep Scaling and Rotation as member variables in the DrawSet. Then use these variables to build the new Matrix every time SetScale/SetRotation method is called. SetMatrix() will use GetSRT() to extract the Scaling/Rotation values one-time.