### PR TITLE
Replace Pointer_stringify() with UTF8ToString().

### DIFF
--- a/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.Base.h
+++ b/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/EffekseerRendererGL.Base.h
@@ -77,7 +77,7 @@ class TextureLoader;
 		int __code = glGetError();                                                                                                \
 		if (__code != GL_NO_ERROR)                                                                                                \
 		{                                                                                                                         \
-			EM_ASM_ARGS({ console.log("GLError filename = " + Pointer_stringify($0) + " , line = " + $1); }, __FILE__, __LINE__); \
+			EM_ASM_ARGS({ console.log("GLError filename = " + UTF8ToString($0) + " , line = " + $1); }, __FILE__, __LINE__); \
 		}                                                                                                                         \
 	}
 #else


### PR DESCRIPTION
Pointer_stringify() was deprecated in emscripten
(https://github.com/emscripten-core/emscripten/pull/8011)