### PR TITLE
Check if EffectImplemented::Create() returns nullptr.

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
@@ -388,6 +388,11 @@ EffectRef Effect::Create(const ManagerRef& manager, const char16_t* path, float 
 
 	eLoader->Unload(data, size);
 
+	if (effect.Get() == nullptr)
+	{
+		return nullptr;
+	}
+
 	effect->SetName(getFilenameWithoutExt(path).c_str());
 
 	return effect;


### PR DESCRIPTION
If you try to load an effect file that exists but contains bad data,
EffectImplemented::Create() will return a nullptr. Attempting to use
this later in the function with effect->SetName() causes a segmentation
fault.