### PR TITLE
Make DirectX and OpenGL backends selectable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if (MSVC)
     option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" OFF)
 endif()
 
+option(BUILD_GL "Build OpenGL" ON)
 option(BUILD_VIEWER "Build viewer" OFF)
 option(BUILD_EDITOR "Build editor" OFF)
 option(BUILD_TEST "Build test" OFF)
@@ -23,6 +24,8 @@ option(USE_LIBPNG_LOADER "use libpng in an internal loader (if it builds viewer 
 option(BUILD_VULKAN "Build vulkan modules" OFF)
 
 if (WIN32)
+    option(BUILD_DX9 "Build DirectX9 modules" ON)
+    option(BUILD_DX11 "Build DirectX11 modules" ON)
     option(BUILD_DX12 "Build DirectX12 modules" ON)
 else()
     option(BUILD_DX12 "Build DirectX12 modules" OFF)
@@ -75,7 +78,7 @@ endif()
 
 option(BUILD_WITH_EASY_PROFILER "Build with easy_profiler to profile" OFF)
 
-if ()
+if (BUILD_DX12)
     add_definitions(-D__EFFEKSEER_BUILD_DX12__)
 endif()
 

--- a/Dev/Cpp/CMakeLists.txt
+++ b/Dev/Cpp/CMakeLists.txt
@@ -74,12 +74,16 @@ endif()
 
 add_subdirectory(Effekseer)
 
-if (WIN32)
+if (BUILD_DX9)
     add_subdirectory(EffekseerRendererDX9)
+endif()
+if (BUILD_DX11)
     add_subdirectory(EffekseerRendererDX11)
 endif()
 
-add_subdirectory(EffekseerRendererGL)
+if (BUILD_GL)
+    add_subdirectory(EffekseerRendererGL)
+endif()
 
 if(BUILD_UNITYPLUGIN OR BUILD_UNITYPLUGIN_FOR_IOS)
     add_subdirectory(EffekseerRendererCommon)

--- a/Dev/Cpp/EffekseerSoundDSound/CMakeLists.txt
+++ b/Dev/Cpp/EffekseerSoundDSound/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 project(EffekseerSoundDSound CXX)
+
 
 set(effekseer_sound_src
 	EffekseerSound/EffekseerSoundDSound.Sound.cpp

--- a/Dev/Cpp/EffekseerSoundXAudio2/CMakeLists.txt
+++ b/Dev/Cpp/EffekseerSoundXAudio2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 project(EffekseerSoundXAudio2 CXX)
 
 set(effekseer_sound_src


### PR DESCRIPTION
I needed to have control over whether the OpenGL and individual DirectX backends are included. So I added options to control them separately.

I also fixed an if statement lacking an argument, and changed the cmake version on two sub projects to match the rest of the project.

