### PR TITLE
Implemented ability to control amount of digits after decimal point

### DIFF
--- a/Dev/Editor/EffekseerCore/Data/OptionValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/OptionValues.cs
@@ -242,6 +242,15 @@ namespace Effekseer.Data
 			private set;
 		}
 
+		[Key(key = "Options_FloatFormatDigits")]
+		[Undo(Undo = false)]
+		public Value.Int FloatFormatDigits
+		{
+			get;
+			set;
+		}
+
+
 		public OptionValues()
 		{
 			RenderingMode = new Value.Enum<RenderMode>(RenderMode.Normal);
@@ -278,6 +287,13 @@ namespace Effekseer.Data
 
 			FileViewerViewMode = new Value.Enum<FileViewMode>(FileViewMode.IconView);
 			FileViewerIconSize = new Value.Int(96, 512, 48);
+			FloatFormatDigits =  new Value.Int(3, 9, 1);
+		}
+		
+		
+		public string GetFloatFormat()
+		{
+			return $"%.{FloatFormatDigits.GetValue()}f"; 
 		}
 
 		public enum RenderMode : int

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/FloatWithRandom.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/FloatWithRandom.cs
@@ -144,7 +144,7 @@ namespace Effekseer.GUI.Component
 			if (Manager.NativeManager.DragFloat2EfkEx(id, internalValue, binding.Step / 10.0f,
 				range_1_min, range_1_max,
 				range_2_min, range_2_max,
-				txt_r1 + ":" + "%.3f", txt_r2 + ":" + "%.3f"))
+				txt_r1 + ":" + Core.Option.GetFloatFormat(), txt_r2 + ":" + Core.Option.GetFloatFormat()))
 			{
 				if (EnableUndo)
 				{

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/Int2.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/Int2.cs
@@ -101,7 +101,7 @@ namespace Effekseer.GUI.Component
 			if (Manager.NativeManager.DragFloat2EfkEx(id, internalValue, step,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:" + "%.3f", "Y:" + "%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat()))
 			{
 				FixValueInternal(isActive);
 			}

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector2D.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector2D.cs
@@ -101,7 +101,7 @@ namespace Effekseer.GUI.Component
 			if (Manager.NativeManager.DragInt2EfkEx(id, internalValue, step,
 				int.MinValue, int.MaxValue,
 				int.MinValue, int.MaxValue,
-				"X:" + "%.3f", "Y:" + "%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat()))
 			{
 				FixValueInternal(isActive);
 			}

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector2DWithRandom.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector2DWithRandom.cs
@@ -169,7 +169,7 @@ namespace Effekseer.GUI.Component
 			if (Manager.NativeManager.DragFloat2EfkEx(id1, internalValue1, step,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:%.3f", "Y:%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat()))
 			{
 				if (EnableUndo)
 				{
@@ -200,7 +200,7 @@ namespace Effekseer.GUI.Component
 			if (Manager.NativeManager.DragFloat2EfkEx(id2, internalValue2, step,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:" + "%.3f", "Y:" + "%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat()))
 			{
 				if (EnableUndo)
 				{

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector3D.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector3D.cs
@@ -112,7 +112,7 @@ namespace Effekseer.GUI.Component
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:" + "%.3f", "Y:" + "%.3f", "Z:" + "%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat(), "Z:" + Core.Option.GetFloatFormat()))
 			{
 				FixValueInternal(isActive);
 			}

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector3DWithRandom.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Component/Vector3DWithRandom.cs
@@ -186,7 +186,7 @@ namespace Effekseer.GUI.Component
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:%.3f", "Y:%.3f", "Z:%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat(), "Z:" + Core.Option.GetFloatFormat()))
 			{
 				if (EnableUndo)
 				{
@@ -227,7 +227,7 @@ namespace Effekseer.GUI.Component
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
 				float.MinValue, float.MaxValue,
-				"X:" + "%.3f", "Y:" + "%.3f", "Z:" + "%.3f"))
+				"X:" + Core.Option.GetFloatFormat(), "Y:" + Core.Option.GetFloatFormat(), "Z:" + Core.Option.GetFloatFormat()))
 			{
 				if (EnableUndo)
 				{

--- a/Dev/release/resources/languages/en/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/en/Effekseer_Options.csv
@@ -43,6 +43,8 @@ Options_DistortionType_Desc,Distortion method
 Options_MouseMappingType_Name,Mouse mapping
 Options_FileViewerViewMode_Name,File view mode
 Options_FileViewerIconSize_Name,File icon size
+Options_FloatFormatDigits_Name,Float format digits
+Options_FloatFormatDigits_Desc,Amount of digits after decimal point
 RenderMode_Normal_Name,Normal
 RenderMode_Wireframe_Name,Wireframe
 RenderMode_NormalWithWireframe_Name,Normal+Wireframe

--- a/Dev/release/resources/languages/es/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/es/Effekseer_Options.csv
@@ -45,6 +45,7 @@ Options_MouseMappingType_Name,Movimiento ratón
 Options_MouseMappingType_Desc,Configuración del movimiento del ratón
 Options_FileViewerViewMode_Name,Modo de vista de archivo
 Options_FileViewerIconSize_Name,Tamaño del icono de archivo
+Options_FloatFormatDigits_Name,Dígitos en formato flotante
 RenderMode_Normal_Name,Normal
 RenderMode_Wireframe_Name,Estructura lineal
 ViewMode_3D_Name,3D

--- a/Dev/release/resources/languages/ja/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/ja/Effekseer_Options.csv
@@ -43,6 +43,7 @@ Options_DistortionType_Desc,歪み方法
 Options_MouseMappingType_Name,マウスマッピング
 Options_FileViewerViewMode_Name,ファイル表示方法
 Options_FileViewerIconSize_Name,ファイルアイコンサイズ
+Options_FloatFormatDigits_Name,フロート形式の数字
 RenderMode_Normal_Name,通常モード
 RenderMode_Wireframe_Name,ワイヤーフレーム
 RenderMode_NormalWithWireframe_Name,通常+ワイヤーフレーム


### PR DESCRIPTION
This is my proposal for feature requested in #811. Amount of digits is configured in Options window.
![image](https://user-images.githubusercontent.com/8457835/162435388-9fba20ae-0f02-41e2-b10a-424f844bef6a.png)

Example with 6 digits.
![image](https://user-images.githubusercontent.com/8457835/162435448-cda8c001-8122-45e2-bcb8-f4d6f47ab4c4.png)

I've also added translated option name in japanese and spanish lang files but since I don't speak these languages I've used translate service and you probably would like to fix these translations.