### PR TITLE
Implemented auto backups of project data 

### DIFF
--- a/Dev/Editor/EffekseerCore/Data/OptionValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/OptionValues.cs
@@ -250,6 +250,14 @@ namespace Effekseer.Data
 			set;
 		}
 
+		[Key(key = "Options_AutoSaveIntervalMin")]
+		[Undo(Undo = false)]
+		public Value.Int AutoSaveIntervalMin
+		{
+			get;
+			set;
+		}
+
 
 		public OptionValues()
 		{
@@ -288,6 +296,7 @@ namespace Effekseer.Data
 			FileViewerViewMode = new Value.Enum<FileViewMode>(FileViewMode.IconView);
 			FileViewerIconSize = new Value.Int(96, 512, 48);
 			FloatFormatDigits =  new Value.Int(3, 9, 1);
+			AutoSaveIntervalMin = new Value.Int(2, 60, 0);
 		}
 		
 		

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
@@ -174,6 +174,8 @@ namespace Effekseer.GUI
 		internal static int resizedCount = 0;
 		internal static int actualWidth = 1;
 
+		private static DateTime lastAutoSaveTime;
+
 		/// <summary>
 		/// if this flag is true, a dialog box on disposing is not shown
 		/// </summary>
@@ -352,6 +354,8 @@ namespace Effekseer.GUI
 
 			TextOffsetY = (NativeManager.GetTextLineHeightWithSpacing() - NativeManager.GetTextLineHeight()) / 2;
 
+			lastAutoSaveTime = DateTime.UtcNow;
+			
 			Network = new Network();
 			Network.Load();
 
@@ -450,6 +454,8 @@ namespace Effekseer.GUI
 
 		public static void Terminate()
 		{
+			Core.SaveBackup(System.IO.Path.GetTempPath() + "/efk_quit.efkbac");
+			
 			var entryDirectory = GetEntryDirectory();
 			System.IO.Directory.SetCurrentDirectory(entryDirectory);
 
@@ -702,6 +708,8 @@ namespace Effekseer.GUI
 			//}
 
 			NativeManager.ResetGUI();
+			
+			UpdateAutoSave();
 
 			if (resetCount < 0)
 			{
@@ -764,6 +772,20 @@ namespace Effekseer.GUI
 			if (actualWidth == 0)
 			{
 				System.Threading.Thread.Sleep(16);
+			}
+		}
+
+		private static void UpdateAutoSave()
+		{
+			int autoSaveIntervalMin = Core.Option.AutoSaveIntervalMin.GetValue();
+			if (autoSaveIntervalMin <= 0) return;
+			
+			
+			DateTime now = DateTime.UtcNow;
+			if (lastAutoSaveTime.AddMinutes(autoSaveIntervalMin) <= now)
+			{
+				Commands.SaveBackup();
+				lastAutoSaveTime = now;
 			}
 		}
 

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Menu/CommandMenuProvider.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Menu/CommandMenuProvider.cs
@@ -79,7 +79,8 @@ namespace Effekseer.GUI.Menu
 				CreateMenuItemFromCommands(Commands.New),
 				CreateMenuItemFromCommands(Commands.Open),
 				CreateMenuItemFromCommands(Commands.Overwrite),
-				CreateMenuItemFromCommands(Commands.SaveAs),
+				CreateMenuItemFromCommands(Commands.SaveAs), 
+				SetupRecoverSubMenu(new MultiLanguageString("Recover")),
 
 				new MenuSeparator(),
 
@@ -116,6 +117,23 @@ namespace Effekseer.GUI.Menu
 			{
 				menu.Controls.Add(control);
 			}
+		}
+
+		private Menu SetupRecoverSubMenu(MultiLanguageString menuTitle)
+		{
+			var recoverMenu = new Menu(menuTitle, Icons.Empty);
+
+			var lastSession = new MenuItem();
+			lastSession.Label = new MultiLanguageString("Recover_LastSession");
+			lastSession.Clicked += () => Commands.RestoreLastSession();
+			recoverMenu.Controls.Add(lastSession);
+			
+			var autoSave = new MenuItem();
+			autoSave.Label = new MultiLanguageString("Recover_AutoSave");
+			autoSave.Clicked += () => Commands.RestoreLastAutoSave();
+			recoverMenu.Controls.Add(autoSave);
+
+			return recoverMenu;
 		}
 
 		private Menu SetupImportSubMenu(MultiLanguageString input)

--- a/Dev/release/resources/languages/en/Effekseer.csv
+++ b/Dev/release/resources/languages/en/Effekseer.csv
@@ -60,6 +60,10 @@ InternalStop,Stop,
 InternalUndo,Undo,
 InternalViewHelp,Manual,
 InternalRenameNode,Rename,
+Recover,Recover
+Recover_LastSession,Last Session
+Recover_AutoSave,Auto Save...
+Recover_LastSession_Error,Unable to find backup file for last session
 RenameNode,Rename,
 Left,Left,
 Load,Load,

--- a/Dev/release/resources/languages/en/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/en/Effekseer_Options.csv
@@ -45,6 +45,8 @@ Options_FileViewerViewMode_Name,File view mode
 Options_FileViewerIconSize_Name,File icon size
 Options_FloatFormatDigits_Name,Float format digits
 Options_FloatFormatDigits_Desc,Amount of digits after decimal point
+Options_AutoSaveIntervalMin_Name,Auto Save Interval (Minutes)
+Options_AutoSaveIntervalMin_Desc,Minutes between backup autosaves. Set to 0 to disable.
 RenderMode_Normal_Name,Normal
 RenderMode_Wireframe_Name,Wireframe
 RenderMode_NormalWithWireframe_Name,Normal+Wireframe

--- a/Dev/release/resources/languages/es/Effekseer.csv
+++ b/Dev/release/resources/languages/es/Effekseer.csv
@@ -60,6 +60,10 @@ InternalStop,Stop,
 InternalUndo,Undo,
 InternalViewHelp,Manual,
 InternalRenameNode,Renombrar,
+Recover,Recuperar
+Recover_LastSession,Última sesión
+Recover_AutoSave,Guardado automático...
+Recover_LastSession_Error,No se puede encontrar el archivo de copia de seguridad de la última sesión
 RenameNode,Renombrar,
 Left,Izquierda,
 Load,Cargar,

--- a/Dev/release/resources/languages/es/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/es/Effekseer_Options.csv
@@ -46,6 +46,8 @@ Options_MouseMappingType_Desc,Configuración del movimiento del ratón
 Options_FileViewerViewMode_Name,Modo de vista de archivo
 Options_FileViewerIconSize_Name,Tamaño del icono de archivo
 Options_FloatFormatDigits_Name,Dígitos en formato flotante
+Options_AutoSaveIntervalMin_Name,Intervalo de guardado automático (minutos)
+Options_AutoSaveIntervalMin_Desc,Minutos entre copias de seguridad automáticas. Establecer en 0 para deshabilitar.
 RenderMode_Normal_Name,Normal
 RenderMode_Wireframe_Name,Estructura lineal
 ViewMode_3D_Name,3D

--- a/Dev/release/resources/languages/ja/Effekseer.csv
+++ b/Dev/release/resources/languages/ja/Effekseer.csv
@@ -61,6 +61,10 @@ InternalStop,停止,
 InternalUndo,元に戻す,
 InternalViewHelp,ヘルプを表示,
 InternalRenameNode,名称の変更,
+Recover,回復
+Recover_LastSession,最後のセッション
+Recover_AutoSave,自動保存...
+Recover_LastSession_Error,最後のセッションのバックアップファイルが見つかりません
 RenameNode,名称の変更,
 Left,左,
 Load,読込,

--- a/Dev/release/resources/languages/ja/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/ja/Effekseer_Options.csv
@@ -44,6 +44,8 @@ Options_MouseMappingType_Name,マウスマッピング
 Options_FileViewerViewMode_Name,ファイル表示方法
 Options_FileViewerIconSize_Name,ファイルアイコンサイズ
 Options_FloatFormatDigits_Name,フロート形式の数字
+Options_AutoSaveIntervalMin_Name,自動保存間隔（分）
+Options_AutoSaveIntervalMin_Desc,バックアップの自動保存間の分。 無効にするには0に設定します。
 RenderMode_Normal_Name,通常モード
 RenderMode_Wireframe_Name,ワイヤーフレーム
 RenderMode_NormalWithWireframe_Name,通常+ワイヤーフレーム


### PR DESCRIPTION
This PR implements simple data recovering options in case of editor crashes, power outages, etc. Implemented functionality is very similiar to data recovering options in Blender and will be familiar to it's users. 

I've added Recover menu which providers two options:
- **Recover Last Session.**
    Open `efk_quit.efkbac` file which is saved in Temp directory when editor is closed under normal operation. This option allows to recover project which was lost when you accidentally closed editor and didn't save changes. If such file is not found an error will be shown.
- **Recover Auto Save**
   Allows user to open Auto Saved files from Temp directory. Auto Saved files will start with `efk_autosave` and will have `efkbac` extension. These files are saved automatically with interval configured in options menu (2 minutes by default). If that interval parameter is set to 0 then auto saves will be disabled. 

Files with `efkbac` extensions are simply `efkefc` files with one additional property `BackupOriginalPath` written in their editor data. This property is used to correcty recover project's path when backup is loaded.

<img src="https://user-images.githubusercontent.com/8457835/162564217-ffe06866-0c19-4071-a416-3bce88070b4b.png" width="600">
<img src="https://user-images.githubusercontent.com/8457835/162564620-6c431edf-496b-4234-9564-466d70fa8a7b.png" width="600">

I've added strings translation in spanish and japanese files, but once again, as I don't speak these languages you may want to rewrite these.



