### PR TITLE
Dynamic expression enabled for middle point of Easing

### DIFF
--- a/Dev/Editor/EffekseerCore/Data/AdvancedRenderCommonValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/AdvancedRenderCommonValues.cs
@@ -258,6 +258,7 @@ namespace Effekseer.Data
 
 			Fixed.Threshold.CanSelectDynamicEquation = true;
 			Easing.Start.CanSelectDynamicEquation = true;
+			Easing.Middle.CanSelectDynamicEquation = true;
 			Easing.End.CanSelectDynamicEquation = true;
 
 			EdgeParam = new EdgeParameter();

--- a/Dev/Editor/EffekseerCore/Data/LocationValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/LocationValues.cs
@@ -78,6 +78,7 @@ namespace Effekseer.Data
 			PVA.Velocity.CanSelectDynamicEquation = true;
 			PVA.Acceleration.CanSelectDynamicEquation = true;
 			Easing.Start.CanSelectDynamicEquation = true;
+			Easing.Middle.CanSelectDynamicEquation = true;
 			Easing.End.CanSelectDynamicEquation = true;
 		}
 

--- a/Dev/Editor/EffekseerCore/Data/RotationValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/RotationValues.cs
@@ -78,6 +78,7 @@ namespace Effekseer.Data
 			PVA.Velocity.CanSelectDynamicEquation = true;
 			PVA.Acceleration.CanSelectDynamicEquation = true;
 			Easing.Start.CanSelectDynamicEquation = true;
+			Easing.Middle.CanSelectDynamicEquation = true;
 			Easing.End.CanSelectDynamicEquation = true;
 		}
 

--- a/Dev/Editor/EffekseerCore/Data/ScaleValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/ScaleValues.cs
@@ -117,6 +117,7 @@ namespace Effekseer.Data
 			PVA.Velocity.CanSelectDynamicEquation = true;
 			PVA.Acceleration.CanSelectDynamicEquation = true;
 			Easing.Start.CanSelectDynamicEquation = true;
+			Easing.Middle.CanSelectDynamicEquation = true;
 			Easing.End.CanSelectDynamicEquation = true;
 		}
 


### PR DESCRIPTION
For some reason middle point in Easing configuration didn't support dynamic expressions in editor altough runtime can support it. This PR enabled usage of dynamic expressions for middle point.