### PR TITLE
Level of Details system

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer.h
+++ b/Dev/Cpp/Effekseer/Effekseer.h
@@ -3757,6 +3757,14 @@ public:
 			\~Japanese trueなら同期的に更新処理を行う。falseなら非同期的に更新処理を行う（次はDraw以外呼び出してはいけない）
 		*/
 		bool SyncUpdate = true;
+
+		/**
+			@brief
+			\~English
+			Position of effects viewer to calculate distance of Level of Details system.
+			Normally should be set the same position which is passed in translation of camera matrix.
+		 */
+		Vector3D ViewerPosition;
 	};
 
 	/**
@@ -4106,6 +4114,26 @@ public:
 	virtual int32_t GetTotalInstanceCount() const = 0;
 
 	/**
+		@brief
+		\~English Returns LOD which is currently utilized for given effect
+	 */
+	virtual int GetCurrentLOD(Handle handle) = 0;
+
+	/**
+		@brief
+		\~English Returns current LOD distance bias. 0 by default.
+	 */
+	virtual float GetLODDistanceBias() const = 0;
+
+	/**
+		@brief
+		\~English
+		Adds given value to calculated distance from viewer which is used for LOD selection.
+		Useful for LODs debugging.
+	 */
+	virtual void SetLODDistanceBias(float distanceBias) = 0;
+	
+	/**
 		@brief	エフェクトのインスタンスに設定されている行列を取得する。
 		@param	handle	[in]	インスタンスのハンドル
 		@return	行列
@@ -4277,6 +4305,7 @@ public:
 
 	/**
 		@brief Stops new particles spawning but continues simulation of already spawned particles
+		@param spawnDisabled Whether to stop particles generation 
 	 */
 	virtual void SetSpawnDisabled(Handle handle, bool spawnDisabled) = 0;
 

--- a/Dev/Cpp/Effekseer/Effekseer.h
+++ b/Dev/Cpp/Effekseer/Effekseer.h
@@ -4439,8 +4439,13 @@ public:
 		@note
 		\~English	It is not required if Update is called.
 		\~Japanese	Updateを実行する際は、実行する必要はない。
+
+		@param ViewerPosition
+		\~English
+		Position of effects viewer to calculate distance of Level of Details system.
+		Normally should be set the same position which is passed in translation of camera matrix.
 	*/
-	virtual void BeginUpdate() = 0;
+	virtual void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) = 0;
 
 	/**
 		@brief

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
@@ -686,6 +686,16 @@ bool EffectImplemented::LoadBody(const uint8_t* data, int32_t size, float mag)
 		}
 	}
 
+	if(m_version >= Version17Alpha3)
+	{
+		binaryReader.Read(LODs.distance1);
+		binaryReader.Read(LODs.distance2);
+		binaryReader.Read(LODs.distance3);
+		LODs.distance1 *= m_maginification;
+		LODs.distance2 *= m_maginification;
+		LODs.distance3 *= m_maginification;
+	}
+
 	// Check
 	if (binaryReader.GetStatus() == BinaryReaderStatus::Failed)
 		return false;

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.cpp
@@ -833,6 +833,9 @@ EffectImplemented::EffectImplemented(const ManagerRef& pManager, const void* pDa
 
 {
 	Culling.Shape = CullingShape::NoneShape;
+	LODs.distance1 = 0.0;
+	LODs.distance2 = 0.0;
+	LODs.distance3 = 0.0;
 }
 
 //----------------------------------------------------------------------------------
@@ -844,6 +847,9 @@ EffectImplemented::EffectImplemented(const SettingRef& setting, const void* pDat
 	, m_version(0)
 {
 	Culling.Shape = CullingShape::NoneShape;
+	LODs.distance1 = 0.0;
+	LODs.distance2 = 0.0;
+	LODs.distance3 = 0.0;
 }
 
 //----------------------------------------------------------------------------------

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectImplemented.h
@@ -104,7 +104,7 @@ class EffectImplemented : public Effect, public ReferenceObject
 	friend class EffectFactory;
 	friend class Instance;
 
-	static const int32_t SupportBinaryVersion = Version17Alpha2;
+	static const int32_t SupportBinaryVersion = Version17Alpha3;
 
 protected:
 	SettingRef m_setting;
@@ -181,6 +181,13 @@ protected:
 		};
 
 	} Culling;
+
+	struct
+	{
+		float distance1;
+		float distance2;
+		float distance3;
+	} LODs;
 
 	//! a flag to reload
 	bool isReloadingOnRenderingThread = false;

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.cpp
@@ -171,6 +171,12 @@ void EffectNodeImplemented::LoadParameter(unsigned char*& pos, EffectNode* paren
 			}
 		}
 
+		if(ef->GetVersion() >= Version17Alpha3)
+		{
+			memcpy(&LODsParam, pos, sizeof(ParameterLODs));
+			pos += sizeof(ParameterLODs);
+		}
+
 		TranslationParam.Load(pos, ef);
 
 		// Local force field

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.h
@@ -38,6 +38,14 @@ enum class BindType : int32_t
 	Always = 2,
 };
 
+enum class NonMatchingLODBehaviour : int32_t
+{
+	Hide = 0,
+	DontSpawn = 1,
+	DontSpawnAndHide = 2
+};
+
+
 enum class TranslationParentBindType : int32_t
 {
 	NotBind = 0,
@@ -103,6 +111,12 @@ struct ParameterCommonValues
 		GenerationTimeOffset.max = 0;
 		GenerationTimeOffset.min = 0;
 	}
+};
+
+struct ParameterLODs
+{
+	int MatchingLODs = 0b1111;
+	NonMatchingLODBehaviour LODBehaviour = NonMatchingLODBehaviour::Hide;
 };
 
 struct ParameterDepthValues
@@ -655,6 +669,7 @@ public:
 	ParameterCommonValues CommonValues;
 	SteeringBehaviorParameter SteeringBehaviorParam;
 	TriggerParameter TriggerParam;
+	ParameterLODs LODsParam;
 
 	TranslationParameter TranslationParam;
 
@@ -758,6 +773,18 @@ public:
 		return renderingUserData_;
 	}
 
+	bool CanDrawWithNonMatchingLOD() const
+	{
+		return LODsParam.LODBehaviour != NonMatchingLODBehaviour::Hide
+		       && LODsParam.LODBehaviour != NonMatchingLODBehaviour::DontSpawnAndHide;
+	}
+
+	bool CanSpawnWithNonMatchingLOD() const
+	{
+		return LODsParam.LODBehaviour != NonMatchingLODBehaviour::DontSpawn
+			   && LODsParam.LODBehaviour != NonMatchingLODBehaviour::DontSpawnAndHide;
+	}
+	
 	void SetRenderingUserData(const RefPtr<RenderingUserData>& renderingUserData) override
 	{
 		renderingUserData_ = renderingUserData;

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
@@ -377,8 +377,7 @@ void Instance::Update(float deltaFrame, bool shown)
 			}
 
 			// if children are removed and going not to generate a child
-			// but make sure that lack of children is not caused by temporarily disabled spawn
-			if (!removed && m_pEffectNode->CommonValues.RemoveWhenChildrenIsExtinct && !GetInstanceGlobal()->IsSpawnDisabled)
+			if (!removed && m_pEffectNode->CommonValues.RemoveWhenChildrenIsExtinct)
 			{
 				removed = !AreChildrenActive();
 			}
@@ -679,6 +678,10 @@ void Instance::Draw(Instance* next, int32_t index, void* userData)
 	if (!m_pEffectNode->IsRendered)
 		return;
 
+	if ((GetInstanceGlobal()->CurrentLevelOfDetails & m_pEffectNode->LODsParam.MatchingLODs) == 0
+	    && !m_pEffectNode->CanDrawWithNonMatchingLOD())
+		return;
+
 	if (m_sequenceNumber != ((ManagerImplemented*)m_pManager)->GetSequenceNumber())
 	{
 		UpdateTransform(0);
@@ -742,5 +745,4 @@ std::array<float, 4> Instance::GetCustomData(int32_t index) const
 
 	return CustomDataFunctions::GetCustomData(parameterCustomData, instanceCustomData, this->m_pContainer->GetRootInstance(), m_LivingTime, m_LivedTime);
 }
-
 } // namespace Effekseer

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
@@ -237,7 +237,8 @@ void InstanceContainer::Draw(bool recursive)
 			}
 		}
 
-		if (count > 0 && m_pEffectNode->IsRendered)
+		if (count > 0 && m_pEffectNode->IsRendered && (m_pGlobal->CurrentLevelOfDetails & m_pEffectNode->LODsParam.MatchingLODs) > 0
+			|| m_pEffectNode->CanDrawWithNonMatchingLOD())
 		{
 			void* userData = m_pGlobal->GetUserData();
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGlobal.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGlobal.h
@@ -67,6 +67,7 @@ public:
 	void EndDeltaFrame();
 
 	bool IsSpawnDisabled = false;
+	int CurrentLevelOfDetails = 0;
 	
 	bool IsGlobalColorSet = false;
 	Color GlobalColor = Color(255, 255, 255, 255);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGroup.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGroup.cpp
@@ -100,6 +100,9 @@ void InstanceGroup::GenerateInstancesIfRequired(float localTime, RandObject& ran
 		}
 	}
 
+	const bool isSpawnRestrictedByLOD = (m_global->CurrentLevelOfDetails & m_effectNode->LODsParam.MatchingLODs) == 0
+		&& !m_effectNode->CanSpawnWithNonMatchingLOD();
+	const bool canSpawn = !m_global->IsSpawnDisabled && !isSpawnRestrictedByLOD;
 	
 	// GenerationTimeOffset can be minus value.
 	// Minus frame particles is generated simultaniously at frame 0.
@@ -108,7 +111,7 @@ void InstanceGroup::GenerateInstancesIfRequired(float localTime, RandObject& ran
 		   localTime >= m_nextGenerationTime)
 	{
 		// Disabled spawn only prevents instance generation but spawn rate should not be affected once spawn is enabled again
-		if(!m_global->IsSpawnDisabled)
+		if(canSpawn)
 		{
 			// Create a particle
 			auto instance = m_manager->CreateInstance(m_effectNode, m_container, this);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.cpp
@@ -71,6 +71,30 @@ ManagerRef Manager::Create(int instance_max, bool autoFlip)
 	return MakeRefPtr<ManagerImplemented>(instance_max, autoFlip);
 }
 
+void ManagerImplemented::DrawSet::UpdateLevelOfDetails(const Vector3D& viewerPosition, float lodDistaceBias)
+{
+	SIMD::Mat43f drawSetMatrix = this->GetGlobalMatrix();
+	float dx = viewerPosition.X - drawSetMatrix.X.GetW();
+	float dy = viewerPosition.Y - drawSetMatrix.Y.GetW();
+	float dz = viewerPosition.Z - drawSetMatrix.Z.GetW();
+	float distanceToViewer = SIMD::Sqrt(dx * dx + dy * dy + dz * dz) + lodDistaceBias;
+	EffectImplemented* effect = (EffectImplemented*)this->ParameterPointer.Get();
+	if(effect->LODs.distance3 > 0.0F && distanceToViewer > effect->LODs.distance3)
+	{
+		GlobalPointer->CurrentLevelOfDetails = 1 << 3;
+	} else if(effect->LODs.distance2 > 0.0F && distanceToViewer > effect->LODs.distance2)
+	{
+		GlobalPointer->CurrentLevelOfDetails = 1 << 2;
+	} else if(effect->LODs.distance1 > 0.0F && distanceToViewer > effect->LODs.distance1)
+	{
+		GlobalPointer->CurrentLevelOfDetails = 1 << 1;
+	} else 
+	{
+		GlobalPointer->CurrentLevelOfDetails = 1 << 0;
+	}
+}
+
+
 SIMD::Mat43f ManagerImplemented::DrawSet::GetGlobalMatrix() const
 {
 	return GlobalMatrix;
@@ -418,6 +442,7 @@ ManagerImplemented::ManagerImplemented(int instance_max, bool autoFlip)
 	, m_FreeFunc(nullptr)
 	, m_randFunc(nullptr)
 	, m_randMax(0)
+	, m_ViewerPosition(Vector3D(0.0, 0.0, 0.0))
 	, m_LodDistanceBias(0.0F)
 {
 	m_setting = Setting::Create();
@@ -1366,8 +1391,8 @@ void ManagerImplemented::DoUpdate(const UpdateParameter& parameter)
 	{
 		times = 1;
 	}
-
-	BeginUpdate();
+	
+	BeginUpdate(parameter.ViewerPosition);
 
 	for (int32_t t = 0; t < times; t++)
 	{
@@ -1394,26 +1419,7 @@ void ManagerImplemented::DoUpdate(const UpdateParameter& parameter)
 			{
 				drawSet.second.GlobalPointer->BeginDeltaFrame(0);
 			}
-
-			SIMD::Mat43f drawSetMatrix = drawSet.second.GetGlobalMatrix();
-			float dx = parameter.ViewerPosition.X - drawSetMatrix.X.GetW();
-			float dy = parameter.ViewerPosition.Y - drawSetMatrix.Y.GetW();
-			float dz = parameter.ViewerPosition.Z - drawSetMatrix.Z.GetW();
-			float distanceToViewer = SIMD::Sqrt(dx * dx + dy * dy + dz * dz) + m_LodDistanceBias;
-			EffectImplemented* effect = (EffectImplemented*)drawSet.second.ParameterPointer.Get();
-			if(effect->LODs.distance3 > 0.0F && distanceToViewer > effect->LODs.distance3)
-			{
-				drawSet.second.GlobalPointer->CurrentLevelOfDetails = 1 << 3;
-			} else if(effect->LODs.distance2 > 0.0F && distanceToViewer > effect->LODs.distance2)
-			{
-				drawSet.second.GlobalPointer->CurrentLevelOfDetails = 1 << 2;
-			} else if(effect->LODs.distance1 > 0.0F && distanceToViewer > effect->LODs.distance1)
-			{
-				drawSet.second.GlobalPointer->CurrentLevelOfDetails = 1 << 1;
-			} else 
-			{
-				drawSet.second.GlobalPointer->CurrentLevelOfDetails = 1 << 0;
-			}
+			
 		}
 
 		for (auto& chunks : instanceChunks_)
@@ -1493,7 +1499,7 @@ void ManagerImplemented::DoUpdate(const UpdateParameter& parameter)
 	m_updateTime = (int)(Effekseer::GetTime() - beginTime);
 }
 
-void ManagerImplemented::BeginUpdate()
+void ManagerImplemented::BeginUpdate(const Vector3D& viewerPosition)
 {
 	m_renderingMutex.lock();
 	m_isLockedWithRenderingMutex = true;
@@ -1503,6 +1509,7 @@ void ManagerImplemented::BeginUpdate()
 		Flip();
 	}
 
+	m_ViewerPosition = viewerPosition;
 	m_sequenceNumber++;
 }
 
@@ -1602,6 +1609,10 @@ void ManagerImplemented::UpdateInstancesByInstanceGlobal(const DrawSet& drawSet)
 
 void ManagerImplemented::UpdateHandleInternal(DrawSet& drawSet)
 {
+	// evaluate LOD
+
+	drawSet.UpdateLevelOfDetails(m_ViewerPosition, m_LodDistanceBias);
+	
 	// calculate dynamic parameters
 	auto e = static_cast<EffectImplemented*>(drawSet.ParameterPointer.Get());
 	assert(e != nullptr);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
@@ -57,6 +57,14 @@ public:
 			\~Japanese trueなら同期的に更新処理を行う。falseなら非同期的に更新処理を行う（次はDraw以外呼び出してはいけない）
 		*/
 		bool SyncUpdate = true;
+
+		/**
+			@brief
+			\~English
+			Position of effects viewer to calculate distance of Level of Details system.
+			Normally should be set the same position which is passed in translation of camera matrix.
+		 */
+		Vector3D ViewerPosition;
 	};
 
 	/**
@@ -405,6 +413,26 @@ public:
 	*/
 	virtual int32_t GetTotalInstanceCount() const = 0;
 
+	/**
+		@brief
+		\~English Returns LOD which is currently utilized for given effect
+	 */
+	virtual int GetCurrentLOD(Handle handle) = 0;
+
+	/**
+		@brief
+		\~English Returns current LOD distance bias. 0 by default.
+	 */
+	virtual float GetLODDistanceBias() const = 0;
+
+	/**
+		@brief
+		\~English
+		Adds given value to calculated distance from viewer which is used for LOD selection.
+		Useful for LODs debugging.
+	 */
+	virtual void SetLODDistanceBias(float distanceBias) = 0;
+	
 	/**
 		@brief	エフェクトのインスタンスに設定されている行列を取得する。
 		@param	handle	[in]	インスタンスのハンドル

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
@@ -739,8 +739,13 @@ public:
 		@note
 		\~English	It is not required if Update is called.
 		\~Japanese	Updateを実行する際は、実行する必要はない。
+
+		@param ViewerPosition
+		\~English
+		Position of effects viewer to calculate distance of Level of Details system.
+		Normally should be set the same position which is passed in translation of camera matrix.
 	*/
-	virtual void BeginUpdate() = 0;
+	virtual void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) = 0;
 
 	/**
 		@brief

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
@@ -110,6 +110,8 @@ private:
 
 		void SetGlobalMatrix(const SIMD::Mat43f& mat);
 
+		void UpdateLevelOfDetails(const Vector3D& viewerPosition, float lodDistanceBias);
+
 	private:
 		SIMD::Mat43f GlobalMatrix;
 	};
@@ -190,6 +192,7 @@ private:
 
 	int m_randMax;
 
+	Vector3D m_ViewerPosition;
 	float m_LodDistanceBias = 0.0F;
 
 	std::queue<std::pair<SoundTag, SoundPlayer::InstanceParameter>> m_requestedSounds;
@@ -404,7 +407,7 @@ public:
 
 	void DoUpdate(const UpdateParameter& parameter);
 
-	void BeginUpdate() override;
+	void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) override;
 
 	void EndUpdate() override;
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
@@ -190,6 +190,8 @@ private:
 
 	int m_randMax;
 
+	float m_LodDistanceBias = 0.0F;
+
 	std::queue<std::pair<SoundTag, SoundPlayer::InstanceParameter>> m_requestedSounds;
 	std::mutex m_soundMutex;
 
@@ -319,6 +321,12 @@ public:
 	int32_t GetInstanceCount(Handle handle) override;
 
 	int32_t GetTotalInstanceCount() const override;
+
+	int GetCurrentLOD(Handle handle) override;
+	
+	float GetLODDistanceBias() const override;
+	
+	void SetLODDistanceBias(float distanceBias) override;
 
 	Matrix43 GetMatrix(Handle handle) override;
 

--- a/Dev/Cpp/Effekseer/Effekseer/Utils/BinaryVersion.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Utils/BinaryVersion.h
@@ -20,6 +20,7 @@ const int32_t Version16Alpha9 = 1608;
 const int32_t Version16 = 1610;
 const int32_t Version17Alpha1 = 1700;
 const int32_t Version17Alpha2 = 1701;
+const int32_t Version17Alpha3 = 1702;
 
 const int32_t CompiledMaterialVersion15 = 1;
 const int32_t CompiledMaterialVersion16 = 1610;

--- a/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
+++ b/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
@@ -215,6 +215,7 @@ bool EffectPlatform::Update()
 	{
 		Effekseer::Manager::UpdateParameter updateParameter;
 		updateParameter.ViewerPosition = renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0);
+		updateParameter.UpdateInterval = 0.0;
 		manager_->Update(updateParameter);
 	}
 

--- a/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
+++ b/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
@@ -202,7 +202,7 @@ bool EffectPlatform::Update()
 
 	if (this->initParam_.IsUpdatedByHandle)
 	{
-		manager_->BeginUpdate();
+		manager_->BeginUpdate(renderer_->GetCameraPosition());
 
 		for (auto h : effectHandles_)
 		{
@@ -213,7 +213,9 @@ bool EffectPlatform::Update()
 	}
 	else
 	{
-		manager_->Update();
+		Effekseer::Manager::UpdateParameter updateParameter;
+		updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+		manager_->Update(updateParameter);
 	}
 
 	BeginRendering();

--- a/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
+++ b/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
@@ -202,7 +202,7 @@ bool EffectPlatform::Update()
 
 	if (this->initParam_.IsUpdatedByHandle)
 	{
-		manager_->BeginUpdate(renderer_->GetCameraPosition());
+		manager_->BeginUpdate(renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0));
 
 		for (auto h : effectHandles_)
 		{
@@ -214,7 +214,7 @@ bool EffectPlatform::Update()
 	else
 	{
 		Effekseer::Manager::UpdateParameter updateParameter;
-		updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+		updateParameter.ViewerPosition = renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0);
 		manager_->Update(updateParameter);
 	}
 

--- a/Dev/Cpp/Test/Runtime/RuntimeTest.cpp
+++ b/Dev/Cpp/Test/Runtime/RuntimeTest.cpp
@@ -1120,6 +1120,59 @@ void SRGBLinearTest()
 #endif
 }
 
+void LODsTest()
+{
+	{
+		srand(0);
+#ifdef _WIN32
+		auto platform = std::make_shared<EffectPlatformDX11>();
+#else
+		auto platform = std::make_shared<EffectPlatformGL>();
+#endif
+		EffectPlatformInitializingParameter param;
+
+		platform->Initialize(param);
+
+		auto h = platform->Play((GetDirectoryPathAsU16(__FILE__) + u"../../../../TestData/Effects/LODs/SimpleLODs.efkefc").c_str());
+
+		auto setDistanceToEffect = [platform, h](double distance)
+		{
+			auto cameraFrontDirection = platform->GetRenderer()->GetCameraFrontDirection();
+			auto cameraPosition = platform->GetRenderer()->GetCameraPosition();
+			platform->GetManager()->SetLocation(h, cameraPosition - cameraFrontDirection * distance);
+		};
+
+		platform->Update();
+
+		setDistanceToEffect(1.0); // Level 0 starts from distance 0
+		platform->Update();
+		platform->Update();
+		platform->TakeScreenshot("LOD_Level_0.png");
+		assert(platform->GetManager()->GetCurrentLOD(h) == 0b0001);
+
+		setDistanceToEffect(6.0); // Level 1 starts from distance 4
+		platform->Update();
+		platform->Update();
+		platform->TakeScreenshot("LOD_Level_1.png");
+		assert(platform->GetManager()->GetCurrentLOD(h) == 0b0010);
+
+		setDistanceToEffect(10.0); // Level 2 starts from distance 8
+		platform->Update();
+		platform->Update();
+		platform->TakeScreenshot("LOD_Level_2.png");
+		assert(platform->GetManager()->GetCurrentLOD(h) == 0b0100);
+		
+		setDistanceToEffect(14.0); // Level 3 starts from distance 12
+		platform->Update();
+		platform->Update();
+		platform->TakeScreenshot("LOD_Level_3.png");
+		assert(platform->GetManager()->GetCurrentLOD(h) == 0b1000);
+		
+
+		platform->Terminate();
+	}
+}
+
 #if defined(__linux__) || defined(__APPLE__) || defined(WIN32)
 
 TestRegister Runtime_StringAndPathHelperTest("Runtime.StringAndPathHelperTest", []() -> void { StringAndPathHelperTest(); });
@@ -1156,4 +1209,5 @@ TestRegister Runtime_RenderLimitTest("Runtime.RenderLimitTest", []() -> void { R
 
 TestRegister Runtime_SRGBLinearTest("Runtime.SRGBLinearTest", []() -> void { SRGBLinearTest(); });
 
+TestRegister Runtime_LODsTest("Runtime.LODsTest", []() -> void { LODsTest(); });
 #endif

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
@@ -714,6 +714,7 @@ void EffectRenderer::Update()
 		Effekseer::Manager::UpdateParameter updateParameter;
 		updateParameter.DeltaFrame = (float)m_step;
 		updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+		updateParameter.UpdateInterval = 0.0;
 		manager_->Update(updateParameter);
 
 		renderer_->SetTime(m_time / 60.0f);

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
@@ -711,7 +711,11 @@ void EffectRenderer::Update()
 			}
 		}
 
-		manager_->Update((float)m_step);
+		Effekseer::Manager::UpdateParameter updateParameter;
+		updateParameter.DeltaFrame = (float)m_step;
+		updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+		manager_->Update(updateParameter);
+
 		renderer_->SetTime(m_time / 60.0f);
 
 		for (size_t i = 0; i < handles_.size(); i++)
@@ -756,6 +760,11 @@ void EffectRenderer::Update(int32_t frame)
 			Update();
 		}
 	}
+}
+
+void EffectRenderer::SetLODDistanceBias(float distanceBias)
+{
+	manager_->SetLODDistanceBias(distanceBias);
 }
 
 void EffectRenderer::Render(std::shared_ptr<RenderImage> renderImage)
@@ -1020,7 +1029,9 @@ void EffectRenderer::ResetEffect()
 	}
 	handles_.clear();
 
-	manager_->Update();
+	Effekseer::Manager::UpdateParameter updateParameter;
+	updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+	manager_->Update(updateParameter);
 }
 
 const ViewerEffectBehavior& EffectRenderer::GetBehavior() const
@@ -1031,6 +1042,16 @@ const ViewerEffectBehavior& EffectRenderer::GetBehavior() const
 void EffectRenderer::SetBehavior(const ViewerEffectBehavior& behavior)
 {
 	behavior_ = behavior;
+}
+
+int EffectRenderer::GetCurrentLOD() const
+{
+	if(handles_.size() == 0)
+	{
+		return 0;
+	}
+
+	return manager_->GetCurrentLOD(handles_[0].Handle);
 }
 
 int32_t EffectRenderer::GetInstanceCount() const

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.h
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.h
@@ -190,6 +190,8 @@ public:
 	void Update(int32_t frame);
 	void Render(std::shared_ptr<RenderImage> renderImage);
 
+	void SetLODDistanceBias(float distanceBias);
+
 	std::shared_ptr<Effekseer::Tool::Effect> GetEffect() const;
 	void SetEffect(std::shared_ptr<Effekseer::Tool::Effect> effect);
 	void ResetEffect();
@@ -197,6 +199,8 @@ public:
 	const ViewerEffectBehavior& GetBehavior() const;
 	void SetBehavior(const ViewerEffectBehavior& behavior);
 
+	int GetCurrentLOD() const;
+	
 	int32_t GetInstanceCount() const;
 
 	void SetStep(int32_t step);

--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
@@ -1255,6 +1255,21 @@ void GUIManager::SameLine(float offset_from_start_x, float spacing)
 	ImGui::SameLine(offset_from_start_x, spacing);
 }
 
+void GUIManager::PushDisabled()
+{
+	ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+}
+
+void GUIManager::PopDisabled()
+{
+	ImGui::PopItemFlag();
+}
+
+void GUIManager::AddRectFilled(float minX, float minY, float maxX, float maxY, uint32_t color, float rounding, int flags)
+{
+	ImGui::GetWindowDrawList()->AddRectFilled(ImVec2(minX, minY), ImVec2(maxX, maxY), color, rounding, flags);
+}
+
 void GUIManager::BeginGroup()
 {
 	ImGui::BeginGroup();
@@ -1263,6 +1278,16 @@ void GUIManager::BeginGroup()
 void GUIManager::EndGroup()
 {
 	ImGui::EndGroup();
+}
+
+void GUIManager::AlignTextToFramePadding()
+{
+	ImGui::AlignTextToFramePadding();
+}
+
+void GUIManager::SetNextItemWidth(float width)
+{
+	ImGui::SetNextItemWidth(width);
 }
 
 void GUIManager::SetCursorPosX(float x)
@@ -1284,6 +1309,45 @@ float GUIManager::GetCursorPosY()
 {
 	return ImGui::GetCursorPosY();
 }
+
+float GUIManager::GetCursorScreenPosX()
+{
+	return ImGui::GetCursorScreenPos().x;
+}
+
+float GUIManager::GetCursorScreenPosY()
+{
+	return ImGui::GetCursorScreenPos().y;
+}
+
+float GUIManager::GetItemRectMinX()
+{
+	return ImGui::GetItemRectMin().x;
+}
+
+float GUIManager::GetItemRectMinY()
+{
+	return ImGui::GetItemRectMin().y;
+}
+
+float GUIManager::GetItemRectMaxX()
+{
+	return ImGui::GetItemRectMax().x;
+}
+
+float GUIManager::GetItemRectMaxY()
+{
+	return ImGui::GetItemRectMax().y;
+}
+float GUIManager::GetItemRectSizeX()
+{
+	return ImGui::GetItemRectSize().x;
+}
+float GUIManager::GetItemRectSizeY()
+{
+	return ImGui::GetItemRectSize().y;
+}
+
 
 float GUIManager::GetTextLineHeight()
 {

--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.h
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.h
@@ -506,13 +506,30 @@ public:
 	void Dummy(const Effekseer::Tool::Vector2I& size);
 	void SameLine(float offset_from_start_x = 0.0f, float spacing = -1.0f);
 
+	void PushDisabled();
+	void PopDisabled();
+
+	void AddRectFilled(float minX, float minY, float maxX, float maxY, uint32_t color, float rounding, int flags);
+
 	void BeginGroup();
 	void EndGroup();
 
+	void AlignTextToFramePadding();
+
+	void SetNextItemWidth(float width);
+	
 	void SetCursorPosX(float x);
 	void SetCursorPosY(float y);
 	float GetCursorPosX();
 	float GetCursorPosY();
+	float GetCursorScreenPosX();
+	float GetCursorScreenPosY();
+	float GetItemRectMinX();
+	float GetItemRectMinY();
+	float GetItemRectMaxX();
+	float GetItemRectMaxY();
+	float GetItemRectSizeX();
+	float GetItemRectSizeY();
 	float GetTextLineHeight();
 	float GetTextLineHeightWithSpacing();
 	float GetFrameHeight();

--- a/Dev/Cpp/Viewer/dll_cs.cxx
+++ b/Dev/Cpp/Viewer/dll_cs.cxx
@@ -3849,6 +3849,16 @@ SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_Render___(void 
 }
 
 
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_SetLODDistanceBias___(void * jarg1, float jarg2) {
+  Effekseer::Tool::EffectRenderer *arg1 = (Effekseer::Tool::EffectRenderer *) 0 ;
+  float arg2 ;
+  
+  arg1 = (Effekseer::Tool::EffectRenderer *)jarg1; 
+  arg2 = (float)jarg2; 
+  (arg1)->SetLODDistanceBias(arg2);
+}
+
+
 SWIGEXPORT void * SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_GetEffect___(void * jarg1) {
   void * jresult ;
   Effekseer::Tool::EffectRenderer *arg1 = (Effekseer::Tool::EffectRenderer *) 0 ;
@@ -3902,6 +3912,18 @@ SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_SetBehavior___(
     return ;
   } 
   (arg1)->SetBehavior((Effekseer::Tool::ViewerEffectBehavior const &)*arg2);
+}
+
+
+SWIGEXPORT int SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_GetCurrentLOD___(void * jarg1) {
+  int jresult ;
+  Effekseer::Tool::EffectRenderer *arg1 = (Effekseer::Tool::EffectRenderer *) 0 ;
+  int result;
+  
+  arg1 = (Effekseer::Tool::EffectRenderer *)jarg1; 
+  result = (int)((Effekseer::Tool::EffectRenderer const *)arg1)->GetCurrentLOD();
+  jresult = result; 
+  return jresult;
 }
 
 
@@ -5338,6 +5360,44 @@ SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_SameLine__SWIG_2___
 }
 
 
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_PushDisabled___(void * jarg1) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  (arg1)->PushDisabled();
+}
+
+
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_PopDisabled___(void * jarg1) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  (arg1)->PopDisabled();
+}
+
+
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_AddRectFilled___(void * jarg1, float jarg2, float jarg3, float jarg4, float jarg5, unsigned int jarg6, float jarg7, int jarg8) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float arg2 ;
+  float arg3 ;
+  float arg4 ;
+  float arg5 ;
+  uint32_t arg6 ;
+  float arg7 ;
+  int arg8 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  arg2 = (float)jarg2; 
+  arg3 = (float)jarg3; 
+  arg4 = (float)jarg4; 
+  arg5 = (float)jarg5; 
+  arg6 = (uint32_t)jarg6; 
+  arg7 = (float)jarg7; 
+  arg8 = (int)jarg8; 
+  (arg1)->AddRectFilled(arg2,arg3,arg4,arg5,arg6,arg7,arg8);
+}
+
+
 SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_BeginGroup___(void * jarg1) {
   efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
   
@@ -5351,6 +5411,24 @@ SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_EndGroup___(void * 
   
   arg1 = (efk::GUIManager *)jarg1; 
   (arg1)->EndGroup();
+}
+
+
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_AlignTextToFramePadding___(void * jarg1) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  (arg1)->AlignTextToFramePadding();
+}
+
+
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_SetNextItemWidth___(void * jarg1, float jarg2) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float arg2 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  arg2 = (float)jarg2; 
+  (arg1)->SetNextItemWidth(arg2);
 }
 
 
@@ -5393,6 +5471,102 @@ SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetCursorPosY___(v
   
   arg1 = (efk::GUIManager *)jarg1; 
   result = (float)(arg1)->GetCursorPosY();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetCursorScreenPosX___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetCursorScreenPosX();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetCursorScreenPosY___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetCursorScreenPosY();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectMinX___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectMinX();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectMinY___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectMinY();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectMaxX___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectMaxX();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectMaxY___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectMaxY();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectSizeX___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectSizeX();
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT float SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_GetItemRectSizeY___(void * jarg1) {
+  float jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  result = (float)(arg1)->GetItemRectSizeY();
   jresult = result; 
   return jresult;
 }

--- a/Dev/Editor/Effekseer/App.cs
+++ b/Dev/Editor/Effekseer/App.cs
@@ -39,6 +39,7 @@ namespace Effekseer
 				typeof(Dock.GlobalValues),
 				typeof(Dock.BehaviorValues),
 				typeof(Dock.Culling),
+				typeof(Dock.LOD),
 				typeof(Dock.Network),
 				typeof(Dock.FileBrowser),
 				typeof(Dock.Dynamic),

--- a/Dev/Editor/Effekseer/Effekseer.csproj
+++ b/Dev/Editor/Effekseer/Effekseer.csproj
@@ -90,6 +90,7 @@
     <Compile Include="GUI\Dock\GenerationLocationValues.cs" />
     <Compile Include="GUI\Dock\LocationAbsValues.cs" />
     <Compile Include="GUI\Dock\LocationValues.cs" />
+    <Compile Include="GUI\Dock\LOD.cs" />
     <Compile Include="GUI\Dock\Network.cs" />
     <Compile Include="GUI\Dock\NodeTreeView.cs" />
     <Compile Include="GUI\Dock\Option.cs" />

--- a/Dev/Editor/Effekseer/GUI/Dock/LOD.cs
+++ b/Dev/Editor/Effekseer/GUI/Dock/LOD.cs
@@ -1,0 +1,118 @@
+﻿using Effekseer.Data.Value;
+using Effekseer.swig;
+using Effekseer.Utl;
+
+namespace Effekseer.GUI.Dock
+{
+	public class LOD : DockPanel
+	{
+
+		public static readonly int LevelCount = 4;
+		public static readonly uint[] LevelColors = {
+			GetColorU32Abgr(0xFF0BE36F),
+			GetColorU32Abgr(0xFFC7E7FE),
+			GetColorU32Abgr(0xFFE3C417),
+			GetColorU32Abgr(0xFFE31F0B) };
+		
+		private bool isFirstUpdate = true;
+		
+		public LOD()
+		{
+			Label = Icons.PanelLOD + Resources.GetString("LOD_Name") + "###LOD";
+		}
+
+		static uint GetColorU32Abgr(uint argb){
+			uint a = (argb >> 24) & 0xFF;
+			uint r = (argb >> 16) & 0xFF;
+			uint g = (argb >> 8) & 0xFF;
+			uint b = (argb) & 0xFF;
+			return (a << 24) | (b << 16) | (g << 8) | r;
+		}
+		
+		private bool ShowLevel(int level, Data.Value.Boolean levelEnabled, Data.Value.Float levelDistance,
+								float minDistance, float maxDistance)
+		{
+			Manager.NativeManager.PushStyleColor(ImGuiColFlags.Text, LevelColors[level]);
+			Manager.NativeManager.Text(MultiLanguageTextProvider.GetText("LOD_Level") + " " + level);
+			Manager.NativeManager.PopStyleColor();
+
+			if (level == 0)
+			{
+				Manager.NativeManager.PushDisabled();
+				Manager.NativeManager.PushStyleVar(ImGuiStyleVarFlags.Alpha, 0.5F);
+			}
+			Manager.NativeManager.NextColumn();
+			bool[] value = { levelEnabled.Value };
+			if (Manager.NativeManager.Checkbox("##level" + level, value))
+			{
+				levelEnabled.SetValue(value[0]);
+			}
+
+			if (levelEnabled.Value)
+			{
+				Manager.NativeManager.SameLine();
+				float[] distance = { levelDistance.Value };
+
+				
+				Manager.NativeManager.DragFloat(MultiLanguageTextProvider.GetText("LOD_Level_Minimum_Distance") + "##distance" + level,
+					distance, 1, minDistance, maxDistance, Core.Option.GetFloatFormat());
+				levelDistance.SetValue(distance[0].Clipping(maxDistance, minDistance));
+				
+			}
+
+			if (level == 0)
+			{
+				Manager.NativeManager.PopStyleVar();
+				Manager.NativeManager.PopDisabled();
+			}
+
+			return levelEnabled.Value;
+		}
+
+		protected override void UpdateInternal()
+		{
+			LevelParameter[] levels = new LevelParameter[]
+			{
+				new LevelParameter(0, Core.LodValues.Lod0Enabled, Core.LodValues.Distance0),
+				new LevelParameter(1, Core.LodValues.Lod1Enabled, Core.LodValues.Distance1),
+				new LevelParameter(2, Core.LodValues.Lod2Enabled, Core.LodValues.Distance2),
+				new LevelParameter(3, Core.LodValues.Lod3Enabled, Core.LodValues.Distance3),
+			};
+			Manager.NativeManager.TextWrapped(MultiLanguageTextProvider.GetText("LOD_Description").Replace("\\n", "\n"));
+			Manager.NativeManager.Columns(2);
+			if (isFirstUpdate)
+			{
+				Manager.NativeManager.SetColumnWidth(0, 60 * Manager.GetUIScaleBasedOnFontSize());
+				isFirstUpdate = false;
+			}
+			{
+				bool showNextLevel = true;
+				for (var i = 0; i < levels.Length && showNextLevel; i++)
+				{
+					var level = levels[i];
+
+					float min = i <= 0 ? 0F : levels[i - 1].LevelDistance.Value;
+					float max = i < levels.Length - 1 && levels[i + 1].IsEnabled.Value ? levels[i + 1].LevelDistance.Value : float.MaxValue ;
+					
+					showNextLevel = ShowLevel(level.LevelIndex, level.IsEnabled, level.LevelDistance, min, max);
+					Manager.NativeManager.NextColumn();
+				}
+			}
+			Manager.NativeManager.Columns(1);
+		}
+
+		struct LevelParameter
+		{
+			public readonly int LevelIndex;
+			public readonly Data.Value.Boolean IsEnabled;
+			public readonly Data.Value.Float LevelDistance;
+
+			public LevelParameter(int levelIndex, Boolean isEnabled, Float levelDistance)
+			{
+				this.LevelIndex = levelIndex;
+				IsEnabled = isEnabled;
+				LevelDistance = levelDistance;
+			}
+		}
+	}
+}

--- a/Dev/Editor/Effekseer/GUI/Dock/ViewerController.cs
+++ b/Dev/Editor/Effekseer/GUI/Dock/ViewerController.cs
@@ -119,6 +119,22 @@ namespace Effekseer.GUI.Dock
 					}
 				}
 			}
+
+			Manager.NativeManager.SameLine();
+			{
+				
+				float[] bias = { Manager.Viewer.LODDistanceBias };
+				Manager.NativeManager.SetNextItemWidth(120F);
+				if (Manager.NativeManager.DragFloat(Resources.GetString("LOD_Bias_Name"), bias))
+				{
+					Manager.Viewer.LODDistanceBias = bias[0];
+				}
+
+				if (Manager.NativeManager.IsItemHovered())
+				{
+					Manager.NativeManager.SetTooltip(Resources.GetString("LOD_Bias_Description"));
+				}
+			}
 		}
 	}
 }

--- a/Dev/Editor/Effekseer/GUI/Menu/WindowMenu.cs
+++ b/Dev/Editor/Effekseer/GUI/Menu/WindowMenu.cs
@@ -20,6 +20,7 @@ namespace Effekseer.GUI.Menu
 			new DockSettings("FCurves", typeof(Dock.FCurves), Icons.PanelFCurve),
 			new DockSettings("Global", typeof(Dock.GlobalValues), Icons.PanelGlobal),
 			new DockSettings("Culling", typeof(Dock.Culling), Icons.PanelCulling),
+			new DockSettings("LOD_Name", typeof(Dock.LOD), Icons.PanelLOD),
 			new DockSettings("DynamicParameter_Name", typeof(Dock.Dynamic), Icons.PanelDynamicParams),
 			new DockSettings("ProceduralModel_Name", typeof(Dock.ProceduralModel), Icons.PanelProceduralModel),
 			new DockSettings("ViewerControls", typeof(Dock.ViewerController), Icons.PanelViewerCtrl),

--- a/Dev/Editor/EffekseerCore/Binary/CommonValues.cs
+++ b/Dev/Editor/EffekseerCore/Binary/CommonValues.cs
@@ -41,7 +41,7 @@ namespace Effekseer.Binary
 			data.Add(bytes);
 
 			if (value.LocationEffectType == Data.TranslationParentEffectType.NotBind_FollowParent ||
-				value.LocationEffectType == Data.TranslationParentEffectType.WhenCreating_FollowParent)
+			    value.LocationEffectType == Data.TranslationParentEffectType.WhenCreating_FollowParent)
 			{
 				data.Add(value.SteeringBehaviorParam.MaxFollowSpeed.Max.GetBytes());
 				data.Add(value.SteeringBehaviorParam.MaxFollowSpeed.Min.GetBytes());
@@ -62,14 +62,22 @@ namespace Effekseer.Binary
 				{
 					data.Add(((ushort)value.TriggerParam.ToStartGeneration.GetValue()).GetBytes());
 				}
+
 				if (value.TriggerParam.ToStopGeneration.Value != Data.TriggerType.None)
 				{
 					data.Add(((ushort)value.TriggerParam.ToStopGeneration.GetValue()).GetBytes());
 				}
+
 				if (value.TriggerParam.ToRemove.Value != Data.TriggerType.None)
 				{
 					data.Add(((ushort)value.TriggerParam.ToRemove.GetValue()).GetBytes());
 				}
+			}
+
+			if (version >= ExporterVersion.Ver17Alpha3)
+			{
+				data.Add(value.LodParameter.MatchingLODs.GetValue().GetBytes());
+				data.Add(value.LodParameter.LodBehaviour.GetValueAsInt().GetBytes());
 			}
 
 			return data.ToArray().ToArray();

--- a/Dev/Editor/EffekseerCore/Binary/Exporter.cs
+++ b/Dev/Editor/EffekseerCore/Binary/Exporter.cs
@@ -23,7 +23,8 @@ namespace Effekseer.Binary
 		Ver1600 = 1610,
 		Ver17Alpha1 = 1700,
 		Ver17Alpha2 = 1701,
-		Latest = Ver17Alpha2,
+		Ver17Alpha3 = 1702,
+		Latest = Ver17Alpha3,
 	}
 
 	public class Exporter
@@ -846,6 +847,12 @@ namespace Effekseer.Binary
 				data.Add(BitConverter.GetBytes(Core.Culling.Sphere.Location.Y));
 				data.Add(BitConverter.GetBytes(Core.Culling.Sphere.Location.Z));
 			}
+
+			int enabledLevels = Core.LodValues.GetEnabledLevelsBits();
+			data.Add(BitConverter.GetBytes((enabledLevels & (1 << 1)) > 0 ? Core.LodValues.Distance1 : 0F));
+			data.Add(BitConverter.GetBytes((enabledLevels & (1 << 2)) > 0 ? Core.LodValues.Distance2 : 0F));
+			data.Add(BitConverter.GetBytes((enabledLevels & (1 << 3)) > 0 ? Core.LodValues.Distance3 : 0F));
+
 
 			// ノード情報出力
 			Action<Data.NodeRoot> outout_rootnode = null;

--- a/Dev/Editor/EffekseerCore/Core.cs
+++ b/Dev/Editor/EffekseerCore/Core.cs
@@ -207,6 +207,8 @@ namespace Effekseer
 
 		static Data.EffectCullingValues culling = new Data.EffectCullingValues();
 
+		private static Data.EffectLODValues lodValues = new Data.EffectLODValues();
+
 		static Data.GlobalValues globalValues = new Data.GlobalValues();
 
 		static Data.RecordingValues recording = new Data.RecordingValues();
@@ -389,6 +391,11 @@ namespace Effekseer
 		public static Data.EffectCullingValues Culling
 		{
 			get { return culling; }
+		}
+
+		public static Data.EffectLODValues LodValues
+		{
+			get { return lodValues; }
 		}
 
 		public static Data.GlobalValues Global
@@ -777,6 +784,7 @@ namespace Effekseer
 			// Adhoc code
 			effectBehavior.Reset();
 			culling = new Data.EffectCullingValues();
+			lodValues = new EffectLODValues();
 			globalValues = new Data.GlobalValues();
 
 			if (recording.RecordingStorageTarget.Value == Data.RecordingStorageTargetTyoe.Local)
@@ -810,6 +818,7 @@ namespace Effekseer
 
 			var behaviorElement = Data.IO.SaveObjectToElement(doc, "Behavior", EffectBehavior, false);
 			var cullingElement = Data.IO.SaveObjectToElement(doc, "Culling", Culling, false);
+			var lodElement = Data.IO.SaveObjectToElement(doc, "LOD", LodValues, false);
 			var globalElement = Data.IO.SaveObjectToElement(doc, "Global", Global, false);
 			var dynamicElement = Data.IO.SaveObjectToElement(doc, "Dynamic", Dynamic, false);
 			var proceduralModelElement = Data.IO.SaveObjectToElement(doc, "ProceduralModel", ProceduralModel, false);
@@ -820,6 +829,7 @@ namespace Effekseer
 
 			if (behaviorElement != null) project_root.AppendChild(behaviorElement);
 			if (cullingElement != null) project_root.AppendChild(cullingElement);
+			if (lodElement != null) project_root.AppendChild(lodElement);
 			if (globalElement != null) project_root.AppendChild(globalElement);
 			if (dynamicElement != null) project_root.AppendChild(dynamicElement);
 			if (proceduralModelElement != null) project_root.AppendChild(proceduralModelElement);
@@ -1014,6 +1024,7 @@ namespace Effekseer
 			if (root == null) return null;
 
 			culling = new Data.EffectCullingValues();
+			lodValues = new EffectLODValues();
 			globalValues = new Data.GlobalValues();
 
 			// Adhoc code
@@ -1031,6 +1042,13 @@ namespace Effekseer
 			{
 				var o = culling as object;
 				Data.IO.LoadObjectFromElement(cullingElement as System.Xml.XmlElement, ref o, false);
+			}
+
+			var lodValuesElement = doc["EffekseerProject"]["LOD"];
+			if (lodValuesElement != null)
+			{
+				var o = Core.lodValues as object;
+				Data.IO.LoadObjectFromElement(lodValuesElement, ref o, false);
 			}
 
 			var globalElement = doc["EffekseerProject"]["Global"];

--- a/Dev/Editor/EffekseerCore/Data/CommonValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/CommonValues.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Effekseer.InternalScript;
 
 namespace Effekseer.Data
 {
@@ -144,8 +146,40 @@ namespace Effekseer.Data
 			}
 		}
 
+		public class LODParameter
+		{
+			[Key(key = "LODParameter_MatchingLODs")]
+			[Shown(Shown = false)]
+			public Value.Int MatchingLODs
+			{
+				get;
+				set;
+			}
+		
+			[Key(key = "LODParameter_LodBehaviour")]
+			[Shown(Shown = false)]
+			public Value.Enum<LODBehaviourType> LodBehaviour
+			{
+				get;
+				set;
+			}
+		
+			public LODParameter()
+			{
+				MatchingLODs = new Value.Int(0b1111);
+				LodBehaviour = new Value.Enum<LODBehaviourType>(LODBehaviourType.Hide);
+			}
+		}
+
 		[IO(Export = true)]
 		public TriggerParameter TriggerParam
+		{
+			get;
+			private set;
+		}
+		
+		[IO(Export = true)]
+		public LODParameter LodParameter
 		{
 			get;
 			private set;
@@ -165,6 +199,8 @@ namespace Effekseer.Data
 			GenerationTimeOffset = new Value.FloatWithRandom(0, float.MaxValue, float.MinValue);
 			SteeringBehaviorParam = new SteeringBehaviorParameter();
 			TriggerParam = new TriggerParameter();
+			LodParameter = new LODParameter();
+			
 
 			// dynamic parameter
 			MaxGeneration.CanSelectDynamicEquation = true;

--- a/Dev/Editor/EffekseerCore/Data/Define.cs
+++ b/Dev/Editor/EffekseerCore/Data/Define.cs
@@ -264,6 +264,16 @@ namespace Effekseer.Data
 		Trigger3 = 1 + (3 << 8),
 	}
 
+	public enum LODBehaviourType : int
+	{
+		[Key(key = "LODBehaviour_Hide")]
+		Hide = 0,
+		[Key(key = "LODBehaviour_DontSpawn")]
+		DontSpawn = 1,
+		[Key(key = "LODBehaviour_DontSpawnAndHide")]
+		DontSpawnAndHide = 2,
+	}
+
 	public class ColorEasingParamater
 	{
 		[Key(key = "Easing_Start")]

--- a/Dev/Editor/EffekseerCore/Data/EffectLODValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/EffectLODValues.cs
@@ -1,0 +1,99 @@
+﻿using Effekseer.Data.Value;
+using IronPython.Modules;
+
+namespace Effekseer.Data
+{
+	public class EffectLODValues
+	{
+		// Not configurable value
+		public Value.Boolean Lod0Enabled
+		{
+			get;
+			private set;
+		}
+		
+		// Not configurable value
+		public Value.Float Distance0
+		{
+			get;
+			private set;
+		}
+
+		[Key(key = "EffectLOD_Lod1Enabled")]
+		public Value.Boolean Lod1Enabled
+		{
+			get;
+			private set;
+		}
+		
+		[Key(key = "EffectLOD_Distance1")]
+		public Value.Float Distance1
+		{
+			get;
+			private set;
+		}
+		
+		[Key(key = "EffectLOD_Lod2Enabled")]
+		public Value.Boolean Lod2Enabled
+		{
+			get;
+			private set;
+		}
+		
+		[Key(key = "EffectLOD_Distance2")]
+		public Value.Float Distance2
+		{
+			get;
+			private set;
+		}
+		
+		[Key(key = "EffectLOD_Lod3Enabled")]
+		public Value.Boolean Lod3Enabled
+		{
+			get;
+			private set;
+		}
+		
+		[Key(key = "EffectLOD_Distance3")]
+		public Value.Float Distance3
+		{
+			get;
+			private set;
+		}
+
+		public EffectLODValues()
+		{
+			Lod0Enabled = new Value.Boolean(true);
+			Distance0 = new Value.Float(0F);
+			
+			Lod1Enabled = new Value.Boolean();
+			Distance1 = new Value.Float(16F);
+			
+			Lod2Enabled = new Value.Boolean();
+			Distance2 = new Value.Float(32F);
+			
+			Lod3Enabled = new Value.Boolean();
+			Distance3 = new Value.Float(64F);
+		}
+
+		public int GetEnabledLevelsBits()
+		{
+			int result = 0;
+			Boolean[] levels = { Lod0Enabled, Lod1Enabled, Lod2Enabled, Lod3Enabled };
+			for (int i = 0; i < levels.Length; i++)
+			{
+				bool isEnabled = levels[i].Value;
+				if (isEnabled)
+				{
+					result |= (1 << i);
+				}
+				else
+				{
+					break;
+				}
+			}
+
+			return result;
+		}
+	}
+}

--- a/Dev/Editor/EffekseerCore/EffekseerCore.csproj
+++ b/Dev/Editor/EffekseerCore/EffekseerCore.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Data\DepthValues.cs" />
     <Compile Include="Data\Dynamic.cs" />
     <Compile Include="Data\EffectCullingValues.cs" />
+    <Compile Include="Data\EffectLODValues.cs" />
     <Compile Include="Data\EffectBehaviorValues.cs" />
     <Compile Include="Data\EnvironmentValues.cs" />
     <Compile Include="Data\OptionValues.cs" />

--- a/Dev/Editor/EffekseerCoreGUI/Application.cs
+++ b/Dev/Editor/EffekseerCoreGUI/Application.cs
@@ -228,6 +228,7 @@ namespace Effekseer
 			MultiLanguageTextProvider.LoadCSV("Effekseer_SpawnMethod.csv");
 			MultiLanguageTextProvider.LoadCSV("Effekseer_Depth.csv");
 			MultiLanguageTextProvider.LoadCSV("Effekseer_Culling.csv");
+			MultiLanguageTextProvider.LoadCSV("Effekseer_LOD.csv");
 			MultiLanguageTextProvider.LoadCSV("Effekseer_Global.csv");
 			MultiLanguageTextProvider.LoadCSV("Effekseer_Sound.csv");
 			MultiLanguageTextProvider.LoadCSV("Effekseer_FCurve.csv");

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Dock/EffectViwer.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Dock/EffectViwer.cs
@@ -68,6 +68,14 @@ namespace Effekseer.GUI.Dock
 			}
 		}
 
+		private static int getLodIndexFromLodBit(int lodBits)
+		{
+			if (lodBits == 0)
+			{
+				return 0;
+			}
+			return (int)((Math.Log10(lodBits & -lodBits)) / Math.Log10(2));
+		}
 		protected override void UpdateInternal()
 		{
 			float textHeight = Manager.NativeManager.GetTextLineHeight();
@@ -97,7 +105,9 @@ namespace Effekseer.GUI.Dock
 			viewMode.Update();
 			Manager.NativeManager.PopItemWidth();
 
+			
 			string perfText =
+				"Current LOD: " + getLodIndexFromLodBit(Manager.Viewer.EffectRenderer.GetCurrentLOD()) + "  " + 
 				"D:" + Manager.Viewer.EffectRenderer.GetAndResetDrawCall().ToString("D3") + "  " +
 				"V:" + Manager.Viewer.EffectRenderer.GetAndResetVertexCount().ToString("D5") + "  " +
 				"P:" + Manager.Viewer.EffectRenderer.GetInstanceCount().ToString("D5") + " ";
@@ -109,6 +119,7 @@ namespace Effekseer.GUI.Dock
 			if (Manager.NativeManager.IsItemHovered())
 			{
 				Manager.NativeManager.SetTooltip(
+					"Current LOD: Level of Detail is currently utilized\n" +
 					"D: Draw calls of current rendering.\n" +
 					"V: Vertex count of current rendering.\n" +
 					"P: Particle count of current rendering.");

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Icons.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Icons.cs
@@ -33,6 +33,7 @@ namespace Effekseer.GUI
 		public const string PanelDynamicParams = "\xec17";
 		public const string PanelAdvancedRenderCommon = "\xec18";
 		public const string PanelProceduralModel = "\xec19";
+		public const string PanelLOD = "\xec26";
 
 		public const string NodeTypeEmpty = "\xec20";
 		public const string NodeTypeSprite = "\xec21";

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
@@ -430,6 +430,15 @@ namespace Effekseer.GUI
 			Core.Culling.Sphere.Location.Z.OnChanged += OnChanged;
 			Core.Culling.Sphere.Radius.OnChanged += OnChanged;
 
+			Core.LodValues.Lod0Enabled.OnChanged += OnChanged;
+			Core.LodValues.Distance0.OnChanged += OnChanged;
+			Core.LodValues.Lod1Enabled.OnChanged += OnChanged;
+			Core.LodValues.Distance1.OnChanged += OnChanged;
+			Core.LodValues.Lod2Enabled.OnChanged += OnChanged;
+			Core.LodValues.Distance2.OnChanged += OnChanged;
+			Core.LodValues.Lod3Enabled.OnChanged += OnChanged;
+			Core.LodValues.Distance3.OnChanged += OnChanged;
+
 			Core.OnAfterLoad += new EventHandler(Core_OnAfterLoad);
 			Core.OnAfterNew += new EventHandler(Core_OnAfterNew);
 			Core.OnReload += new EventHandler(Core_OnReload);

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Viewer.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Viewer.cs
@@ -58,6 +58,12 @@ namespace Effekseer.GUI
 			}
 		}
 
+		public float LODDistanceBias
+		{
+			get;
+			set;
+		}
+
 		public Viewer(HardwareDevice hardwareDevice)
 		{
 			this.hardwareDevice = hardwareDevice;
@@ -411,6 +417,8 @@ namespace Effekseer.GUI
 					Core.Option.MouseRotInvY,
 					Core.Option.MouseSlideInvX,
 					Core.Option.MouseSlideInvY);
+				
+				EffectRenderer.SetLODDistanceBias(LODDistanceBias);
 			}
 			else
 			{

--- a/Dev/Editor/EffekseerCoreGUI/swig/EffectRenderer.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/EffectRenderer.cs
@@ -78,6 +78,10 @@ public class EffectRenderer : global::System.IDisposable {
     EffekseerNativePINVOKE.EffectRenderer_Render(swigCPtr, RenderImage.getCPtr(renderImage));
   }
 
+  public void SetLODDistanceBias(float distanceBias) {
+    EffekseerNativePINVOKE.EffectRenderer_SetLODDistanceBias(swigCPtr, distanceBias);
+  }
+
   public Effect GetEffect() {
     global::System.IntPtr cPtr = EffekseerNativePINVOKE.EffectRenderer_GetEffect(swigCPtr);
     Effect ret = (cPtr == global::System.IntPtr.Zero) ? null : new Effect(cPtr, true);
@@ -100,6 +104,11 @@ public class EffectRenderer : global::System.IDisposable {
   public void SetBehavior(ViewerEffectBehavior behavior) {
     EffekseerNativePINVOKE.EffectRenderer_SetBehavior(swigCPtr, ViewerEffectBehavior.getCPtr(behavior));
     if (EffekseerNativePINVOKE.SWIGPendingException.Pending) throw EffekseerNativePINVOKE.SWIGPendingException.Retrieve();
+  }
+
+  public int GetCurrentLOD() {
+    int ret = EffekseerNativePINVOKE.EffectRenderer_GetCurrentLOD(swigCPtr);
+    return ret;
   }
 
   public int GetInstanceCount() {

--- a/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
@@ -1047,6 +1047,9 @@ class EffekseerNativePINVOKE {
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_Render___")]
   public static extern void EffectRenderer_Render(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_SetLODDistanceBias___")]
+  public static extern void EffectRenderer_SetLODDistanceBias(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_GetEffect___")]
   public static extern global::System.IntPtr EffectRenderer_GetEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -1061,6 +1064,9 @@ class EffekseerNativePINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_SetBehavior___")]
   public static extern void EffectRenderer_SetBehavior(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_GetCurrentLOD___")]
+  public static extern int EffectRenderer_GetCurrentLOD(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_GetInstanceCount___")]
   public static extern int EffectRenderer_GetInstanceCount(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -1446,11 +1452,26 @@ class EffekseerNativePINVOKE {
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_SameLine__SWIG_2___")]
   public static extern void GUIManager_SameLine__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PushDisabled___")]
+  public static extern void GUIManager_PushDisabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PopDisabled___")]
+  public static extern void GUIManager_PopDisabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_AddRectFilled___")]
+  public static extern void GUIManager_AddRectFilled(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, uint jarg6, float jarg7, int jarg8);
+
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_BeginGroup___")]
   public static extern void GUIManager_BeginGroup(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_EndGroup___")]
   public static extern void GUIManager_EndGroup(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_AlignTextToFramePadding___")]
+  public static extern void GUIManager_AlignTextToFramePadding(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_SetNextItemWidth___")]
+  public static extern void GUIManager_SetNextItemWidth(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_SetCursorPosX___")]
   public static extern void GUIManager_SetCursorPosX(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
@@ -1463,6 +1484,30 @@ class EffekseerNativePINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetCursorPosY___")]
   public static extern float GUIManager_GetCursorPosY(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetCursorScreenPosX___")]
+  public static extern float GUIManager_GetCursorScreenPosX(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetCursorScreenPosY___")]
+  public static extern float GUIManager_GetCursorScreenPosY(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectMinX___")]
+  public static extern float GUIManager_GetItemRectMinX(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectMinY___")]
+  public static extern float GUIManager_GetItemRectMinY(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectMaxX___")]
+  public static extern float GUIManager_GetItemRectMaxX(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectMaxY___")]
+  public static extern float GUIManager_GetItemRectMaxY(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectSizeX___")]
+  public static extern float GUIManager_GetItemRectSizeX(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetItemRectSizeY___")]
+  public static extern float GUIManager_GetItemRectSizeY(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_GetTextLineHeight___")]
   public static extern float GUIManager_GetTextLineHeight(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/Dev/Editor/EffekseerCoreGUI/swig/GUIManager.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/GUIManager.cs
@@ -298,12 +298,32 @@ public class GUIManager : global::System.IDisposable {
     EffekseerNativePINVOKE.GUIManager_SameLine__SWIG_2(swigCPtr);
   }
 
+  public void PushDisabled() {
+    EffekseerNativePINVOKE.GUIManager_PushDisabled(swigCPtr);
+  }
+
+  public void PopDisabled() {
+    EffekseerNativePINVOKE.GUIManager_PopDisabled(swigCPtr);
+  }
+
+  public void AddRectFilled(float minX, float minY, float maxX, float maxY, uint color, float rounding, int flags) {
+    EffekseerNativePINVOKE.GUIManager_AddRectFilled(swigCPtr, minX, minY, maxX, maxY, color, rounding, flags);
+  }
+
   public void BeginGroup() {
     EffekseerNativePINVOKE.GUIManager_BeginGroup(swigCPtr);
   }
 
   public void EndGroup() {
     EffekseerNativePINVOKE.GUIManager_EndGroup(swigCPtr);
+  }
+
+  public void AlignTextToFramePadding() {
+    EffekseerNativePINVOKE.GUIManager_AlignTextToFramePadding(swigCPtr);
+  }
+
+  public void SetNextItemWidth(float width) {
+    EffekseerNativePINVOKE.GUIManager_SetNextItemWidth(swigCPtr, width);
   }
 
   public void SetCursorPosX(float x) {
@@ -321,6 +341,46 @@ public class GUIManager : global::System.IDisposable {
 
   public float GetCursorPosY() {
     float ret = EffekseerNativePINVOKE.GUIManager_GetCursorPosY(swigCPtr);
+    return ret;
+  }
+
+  public float GetCursorScreenPosX() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetCursorScreenPosX(swigCPtr);
+    return ret;
+  }
+
+  public float GetCursorScreenPosY() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetCursorScreenPosY(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectMinX() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectMinX(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectMinY() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectMinY(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectMaxX() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectMaxX(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectMaxY() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectMaxY(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectSizeX() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectSizeX(swigCPtr);
+    return ret;
+  }
+
+  public float GetItemRectSizeY() {
+    float ret = EffekseerNativePINVOKE.GUIManager_GetItemRectSizeY(swigCPtr);
     return ret;
   }
 

--- a/Dev/release/resources/icons/MenuIcons.png
+++ b/Dev/release/resources/icons/MenuIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fabe35c8b63066ff2d7d7375444ce5002eb523d85bebd103c4d92800d8a20f8
-size 28387
+oid sha256:ba9c6c357ce00e779dfca398c5d183546b2fc3e6bf92443473b4e5a18000055d
+size 30789

--- a/Dev/release/resources/languages/en/Effekseer_LOD.csv
+++ b/Dev/release/resources/languages/en/Effekseer_LOD.csv
@@ -1,0 +1,14 @@
+﻿LOD_Name,Levels of Details
+LOD_Level,Level
+LOD_Description,Configure Levels of Details to utilize.\nWhen level is enabled you can specify minimum distance away from viewer for the LOD to be selected
+LOD_Level_Minimum_Distance,Minimum Distance
+LODBehaviour_Hide_Name,Hide Particles
+LODBehaviour_DontSpawn_Name,Stop New Particles Spawn
+LODBehaviour_DontSpawnAndHide_Name,Stop New Particles Spawn and Hide Existing
+LOD_NotConfigured,Levels of Detail are not configured
+LOD_Configure,Configure
+LOD_SelectMatching,Select LODs on which node behaves as usual
+LOD_Behaviour,How particle should behave when LOD doesn't match selection
+LOD_ApplyToChildren,Apply LOD Settings To Children
+LOD_Bias_Name,LOD Distance Bias (m)
+LOD_Bias_Description,Adds given value to calculated distance from viewer. Useful for LODs preview.

--- a/Dev/release/resources/languages/es/Effekseer_LOD.csv
+++ b/Dev/release/resources/languages/es/Effekseer_LOD.csv
@@ -1,0 +1,14 @@
+﻿LOD_Name,Niveles de detalles
+LOD_Level,Nivel
+LOD_Description,Configure los niveles de detalles para utilizar.\nCuando el nivel está habilitado, puede especificar la distancia mínima del espectador para que se seleccione el LOD
+LOD_Level_Minimum_Distance,Distancia minima
+LODBehaviour_Hide_Name,Ocultar partículas
+LODBehaviour_DontSpawn_Name,Detener el engendro de nuevas partículas
+LODBehaviour_DontSpawnAndHide_Name,Detenga la aparición de nuevas partículas y oculte las existentes
+LOD_NotConfigured,Los niveles de detalle no están configurados
+LOD_Configure,Configurar
+LOD_SelectMatching,Seleccione los LOD en los que el nodo se comporta como de costumbre
+LOD_Behaviour,Cómo debe comportarse la partícula cuando el LOD no coincide con la selección
+LOD_ApplyToChildren,Aplicar configuración de LOD a los niños
+LOD_Bias_Name,Sesgo de distancia LOD (m)
+LOD_Bias_Description,Agrega el valor dado a la distancia calculada desde el espectador. Útil para la vista previa de LOD.

--- a/Dev/release/resources/languages/ja/Effekseer_LOD.csv
+++ b/Dev/release/resources/languages/ja/Effekseer_LOD.csv
@@ -1,0 +1,14 @@
+﻿LOD_Name,詳細のレベル
+LOD_Level,レベル
+LOD_Description,使用する詳細レベルを構成します。\nレベルが有効になっている場合、選択するLODのビューアからの最小距離を指定できます。
+LOD_Level_Minimum_Distance,最小距離
+LODBehaviour_Hide_Name,パーティクルを非表示にする
+LODBehaviour_DontSpawn_Name,新しいパーティクルのスポーンを停止します
+LODBehaviour_DontSpawnAndHide_Name,新しいパーティクルのスポーンを停止し、既存のパーティクルを非表示にします
+LOD_NotConfigured,詳細レベルは構成されていません
+LOD_Configure,構成、設定
+LOD_SelectMatching,ノードが通常どおりに動作するLODを選択します
+LOD_Behaviour,LODが選択と一致しない場合のパーティクルの動作
+LOD_ApplyToChildren,LOD設定を子供に適用する
+LOD_Bias_Name,LOD距離バイアス（m）
+LOD_Bias_Description,視聴者からの計算された距離に指定された値を追加します。 LODのプレビューに役立ちます。


### PR DESCRIPTION
This PR introduces basic implementation of levels of details system for effects.  It provides a way for effects artists to create particle effects that make more efficient use of resources. E.g. parts of effect can be turned off when the player is too far away to effectively appreciate them.
 
### Levels configuration
User can configure enabled levels with their distances in newly added panel. Level 0 is always enabled and starts from distance 0.
<img src="https://user-images.githubusercontent.com/8457835/166123434-831e04ca-b3a4-4c70-9497-502ab191518d.png" width="500" >

### Details configuration
Another notable UI change was done in tree node hiearchy view. Near every node now there is a LOD configuration button which also displays to which levels that node is attached to.
<img src="https://user-images.githubusercontent.com/8457835/166123491-26f49a05-4472-487b-becd-9f54c4f24af0.png" width="500" >

Clicking LOD configuration button reveals level selector along with LOD behaviour configuration which determines what happens with particles when current effect's LOD stops matching selected levels. If there are no levels configured in this effect this popup will suggest to configure them by navigating user to Level of Details panel.

Available LOD behaviours types:

- Hide Particles - continues particles update and spawn at the usual rate but all particles under that node no longer submitted for rendering.
- Stop New Particles Spawn - particles are still rendered but new particles no longer spawned. 'Destroy when no more children' will not trigger node destruction if lack of children was caused by LOD behaviour.
- Stop New Particles Spawn and Hide Existing - combines behaviour of two previous types.

<img src="https://user-images.githubusercontent.com/8457835/166123548-1724ce56-f484-4fc9-b3df-eec723e1ca07.png" width="500" >

Changes to node's LOD settings will be automatically propagated to it's existing children but newly created child nodes won't be affected. User can use `Apply LOD settings to children` to force children to use same settings.

I also added label which displayes current LOD when effect is played in editor and introduced `LOD Distance Bias` which affects calculation of current LOD to ease LODs behaviour preview.
<img src="https://user-images.githubusercontent.com/8457835/166123893-35ea7b9c-7996-4fd0-9bca-7f5cbd191789.png" width="500" >



This PR also increments effects version to 1703 since there are changes to effect's data structure. I also added a new lang file `Effekseer_LOD.csv` in which I've put all strings related to LOD system. Since I don't speak japanese nor spanish newly added strings were automatically translated with translation service. 

I also added new field to `Effekseer::Manager::UpdateParameter` - `ViewerPosition`, it is used to calculate distance for level of details calculation. This change probably should be reflected in update notes since if that position is not provided LOD system wont work as expected.  
