### PR TITLE
Fixed missing bindings for PushTextWrapPos(float)/PopTextWrapPos()/ItemHovered(float)

### DIFF
--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.cpp
@@ -2133,6 +2133,21 @@ bool GUIManager::IsMouseDoubleClicked(int button)
 	return ImGui::IsMouseDoubleClicked(button);
 }
 
+void GUIManager::PushTextWrapPos(float pos)
+{
+	ImGui::PushTextWrapPos(pos);
+}
+
+void GUIManager::PopTextWrapPos()
+{
+	ImGui::PopTextWrapPos();
+}
+
+bool GUIManager::IsItemHovered(float f)
+{
+	return ImGui::IsItemHovered(f);
+}
+
 bool GUIManager::IsItemHovered()
 {
 	return ImGui::IsItemHovered();

--- a/Dev/Cpp/Viewer/GUI/efk.GUIManager.h
+++ b/Dev/Cpp/Viewer/GUI/efk.GUIManager.h
@@ -748,6 +748,10 @@ public:
 	bool IsMouseReleased(int button);
 	bool IsMouseDoubleClicked(int button);
 
+	void PushTextWrapPos(float pos);
+	void PopTextWrapPos();
+	
+	bool IsItemHovered(float f);
 	bool IsItemHovered();
 	bool IsItemActive();
 	bool IsItemFocused();

--- a/Dev/Cpp/Viewer/dll_cs.cxx
+++ b/Dev/Cpp/Viewer/dll_cs.cxx
@@ -9408,7 +9408,39 @@ SWIGEXPORT unsigned int SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_IsMouseDoub
 }
 
 
-SWIGEXPORT unsigned int SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_IsItemHovered___(void * jarg1) {
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_PushTextWrapPos___(void * jarg1, float jarg2) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float arg2 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  arg2 = (float)jarg2; 
+  (arg1)->PushTextWrapPos(arg2);
+}
+
+
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_PopTextWrapPos___(void * jarg1) {
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  (arg1)->PopTextWrapPos();
+}
+
+
+SWIGEXPORT unsigned int SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_IsItemHovered__SWIG_0___(void * jarg1, float jarg2) {
+  unsigned int jresult ;
+  efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
+  float arg2 ;
+  bool result;
+  
+  arg1 = (efk::GUIManager *)jarg1; 
+  arg2 = (float)jarg2; 
+  result = (bool)(arg1)->IsItemHovered(arg2);
+  jresult = result; 
+  return jresult;
+}
+
+
+SWIGEXPORT unsigned int SWIGSTDCALL CSharp_Effekseerfswig_GUIManager_IsItemHovered__SWIG_1___(void * jarg1) {
   unsigned int jresult ;
   efk::GUIManager *arg1 = (efk::GUIManager *) 0 ;
   bool result;

--- a/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
@@ -1422,12 +1422,6 @@ class EffekseerNativePINVOKE {
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PopItemWidth___")]
   public static extern void GUIManager_PopItemWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PushTextWrapPos___")]
-  public static extern void GUIManager_PushTextWrapPos(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
-
-  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PopTextWrapPos___")]
-  public static extern void GUIManager_PopTextWrapPos(global::System.Runtime.InteropServices.HandleRef jarg1);
-
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_Separator___")]
   public static extern void GUIManager_Separator(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -2108,6 +2102,12 @@ class EffekseerNativePINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_IsMouseDoubleClicked___")]
   public static extern bool GUIManager_IsMouseDoubleClicked(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PushTextWrapPos___")]
+  public static extern void GUIManager_PushTextWrapPos(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_PopTextWrapPos___")]
+  public static extern void GUIManager_PopTextWrapPos(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_GUIManager_IsItemHovered__SWIG_0___")]
   public static extern bool GUIManager_IsItemHovered__SWIG_0(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);

--- a/Dev/Editor/EffekseerCoreGUI/swig/GUIManager.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/GUIManager.cs
@@ -265,14 +265,6 @@ public class GUIManager : global::System.IDisposable {
     EffekseerNativePINVOKE.GUIManager_PopItemWidth(swigCPtr);
   }
 
-  public void PushTextWrapPos(float wrap_local_pos_x) {
-    EffekseerNativePINVOKE.GUIManager_PushTextWrapPos(swigCPtr, wrap_local_pos_x);
-  }
-
-  public void PopTextWrapPos() {
-    EffekseerNativePINVOKE.GUIManager_PopTextWrapPos(swigCPtr);
-  }
-
   public void Separator() {
     EffekseerNativePINVOKE.GUIManager_Separator(swigCPtr);
   }
@@ -1363,8 +1355,16 @@ public class GUIManager : global::System.IDisposable {
     return ret;
   }
 
-  public bool IsItemHovered(float time_threshold) {
-    bool ret = EffekseerNativePINVOKE.GUIManager_IsItemHovered__SWIG_0(swigCPtr, time_threshold);
+  public void PushTextWrapPos(float pos) {
+    EffekseerNativePINVOKE.GUIManager_PushTextWrapPos(swigCPtr, pos);
+  }
+
+  public void PopTextWrapPos() {
+    EffekseerNativePINVOKE.GUIManager_PopTextWrapPos(swigCPtr);
+  }
+
+  public bool IsItemHovered(float f) {
+    bool ret = EffekseerNativePINVOKE.GUIManager_IsItemHovered__SWIG_0(swigCPtr, f);
     return ret;
   }
 


### PR DESCRIPTION
Apparently these got lost during PR #819 