### PR TITLE
Particle's LOD now updated when editor is paused.

### DIFF
--- a/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
@@ -604,6 +604,15 @@ void EffectRenderer::PlayEffect()
 	m_rootScale.Z = behavior_.ScaleZ;
 }
 
+void EffectRenderer::UpdatePaused()
+{
+	Effekseer::Manager::UpdateParameter updateParameter;
+	updateParameter.DeltaFrame = 0.0F;
+	updateParameter.UpdateInterval = 0.0f;
+	updateParameter.ViewerPosition = renderer_->GetCameraPosition();
+	manager_->Update(updateParameter);
+}
+
 void EffectRenderer::Update()
 {
 	if (behavior_.TimeSpan > 0 && m_time > 0 && m_time % behavior_.TimeSpan == 0)

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.h
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.h
@@ -205,6 +205,7 @@ public:
 	void ResizeScreen(const Vector2I& screenSize);
 
 	void PlayEffect();
+	void UpdatePaused();
 	void Update();
 	void Update(int32_t frame);
 	void Render(std::shared_ptr<RenderImage> renderImage);

--- a/Dev/Cpp/Viewer/dll_cs.cxx
+++ b/Dev/Cpp/Viewer/dll_cs.cxx
@@ -3888,6 +3888,14 @@ SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_PlayEffect___(v
 }
 
 
+SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_UpdatePaused___(void * jarg1) {
+  Effekseer::Tool::EffectRenderer *arg1 = (Effekseer::Tool::EffectRenderer *) 0 ;
+  
+  arg1 = (Effekseer::Tool::EffectRenderer *)jarg1; 
+  (arg1)->UpdatePaused();
+}
+
+
 SWIGEXPORT void SWIGSTDCALL CSharp_Effekseerfswig_EffectRenderer_Update__SWIG_0___(void * jarg1) {
   Effekseer::Tool::EffectRenderer *arg1 = (Effekseer::Tool::EffectRenderer *) 0 ;
   

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Viewer.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Viewer.cs
@@ -578,6 +578,11 @@ namespace Effekseer.GUI
 					stepFrame = Math.Min(stepFrame, 4);
 
 					StepViewer(stepFrame, true);
+				} else if (IsPlaying && IsPaused)
+				{
+					// need to update LOD which could have changed because of changed camera position
+					// even if effect is paused
+					EffectRenderer.UpdatePaused();
 				}
 
 				// update environment
@@ -840,6 +845,7 @@ namespace Effekseer.GUI
 				{
 					if ((int)current == (int)new_frame)
 					{
+						StepEffectFrame((int)new_frame);
 					}
 					else if ((int)current > (int)new_frame)
 					{

--- a/Dev/Editor/EffekseerCoreGUI/swig/EffectRenderer.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/EffectRenderer.cs
@@ -66,6 +66,10 @@ public class EffectRenderer : global::System.IDisposable {
     EffekseerNativePINVOKE.EffectRenderer_PlayEffect(swigCPtr);
   }
 
+  public void UpdatePaused() {
+    EffekseerNativePINVOKE.EffectRenderer_UpdatePaused(swigCPtr);
+  }
+
   public void Update() {
     EffekseerNativePINVOKE.EffectRenderer_Update__SWIG_0(swigCPtr);
   }

--- a/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
+++ b/Dev/Editor/EffekseerCoreGUI/swig/EffekseerNativePINVOKE.cs
@@ -1053,6 +1053,9 @@ class EffekseerNativePINVOKE {
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_PlayEffect___")]
   public static extern void EffectRenderer_PlayEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+  [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_UpdatePaused___")]
+  public static extern void EffectRenderer_UpdatePaused(global::System.Runtime.InteropServices.HandleRef jarg1);
+
   [global::System.Runtime.InteropServices.DllImport("Viewer", EntryPoint="CSharp_Effekseerfswig_EffectRenderer_Update__SWIG_0___")]
   public static extern void EffectRenderer_Update__SWIG_0(global::System.Runtime.InteropServices.HandleRef jarg1);
 


### PR DESCRIPTION
When editor is paused LOD selection is not working since `Manager::Update` is not called, and it might be confusing for fx artist. I've added call for `Manager::Update` with `DeltaFrame = 0` and `UpdateInterval = 0` when editor is paused. So now effect stays paused but LOD selection logic is still performed.