### PR TITLE
Modify APIs that about LOD

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer.h
+++ b/Dev/Cpp/Effekseer/Effekseer.h
@@ -3774,6 +3774,9 @@ namespace Effekseer
 class Manager : public IReference
 {
 public:
+	static constexpr int32_t LayerCount = 32;
+
+public:
 	/**
 		@brief
 		\~English Parameters when a manager is updated
@@ -3807,18 +3810,9 @@ public:
 			\~Japanese trueなら同期的に更新処理を行う。falseなら非同期的に更新処理を行う（次はDraw以外呼び出してはいけない）
 		*/
 		bool SyncUpdate = true;
-
-		/**
-			@brief
-			\~English
-			Position of effects viewer to calculate distance of Level of Details system.
-			Normally should be set the same position which is passed in translation of camera matrix.
-		 */
-		Vector3D ViewerPosition;
 	};
 
 	/**
-	@brief
 		@brief
 		\~English Parameters for Manager::Draw and Manager::DrawHandle
 		\~Japanese Manager::Draw and Manager::DrawHandleに使用するパラメーター
@@ -3859,6 +3853,36 @@ public:
 		bool IsSortingEffectsEnabled = false;
 
 		DrawParameter();
+	};
+	
+	/**
+		@brief
+		\~English Parameters of Manager::SetLayerParameter to be set for each layer index.
+		\~Japanese Manager::SetLayerParameterにレイヤーごとに設定するパラメーター
+	*/
+	struct LayerParameter
+	{
+		/**
+			@brief
+			\~English
+			Position of effects viewer to calculate distance of Level of Details system.
+			Normally should be set the same position which is passed in translation of camera matrix.
+			\~Japanese
+			LODシステムで使用される視点の位置。
+			通常はカメラの位置と同じ値を指定する。
+		*/
+		Vector3D ViewerPosition = {0.0f, 0.0f, 0.0f};
+		
+		/**
+			@brief
+			\~English
+			Adds given value to calculated distance from viewer which is used for LOD selection.
+			Useful for LODs debugging.
+			\~Japanese
+			LODの選択に使用される、視点からの計算された距離に加算される値。
+			LODのデバッグに役に立ちます。
+		*/
+		float DistanceBias = 0.0f;
 	};
 
 protected:
@@ -4167,21 +4191,27 @@ public:
 		@brief
 		\~English Returns LOD which is currently utilized for given effect
 	 */
-	virtual int GetCurrentLOD(Handle handle) = 0;
+	virtual int32_t GetCurrentLOD(Handle handle) = 0;
 
 	/**
 		@brief
-		\~English Returns current LOD distance bias. 0 by default.
+		\~English Returns current specified LOD parameters.
+		\~Japanese 現在指定されているLODパラメータを返します
 	 */
-	virtual float GetLODDistanceBias() const = 0;
+	virtual const LayerParameter& GetLayerParameter(int32_t layer) const = 0;
 
 	/**
 		@brief
-		\~English
-		Adds given value to calculated distance from viewer which is used for LOD selection.
-		Useful for LODs debugging.
+		\~English Set layer parameters.
+		\~Japanese レイヤーパラメータを設定する。
+		@param	layer
+		\~English	Layer index
+		\~Japanese	レイヤーのインデックス
+		@param	layerParameter
+		\~English	Layer parameters
+		\~Japanese	レイヤーパラメータ
 	 */
-	virtual void SetLODDistanceBias(float distanceBias) = 0;
+	virtual void SetLayerParameter(int32_t layer, const LayerParameter& layerParameter) = 0;
 
 	/**
 		@brief	エフェクトのインスタンスに設定されている行列を取得する。
@@ -4372,7 +4402,7 @@ public:
 		\~English For example, if effect's layer is 1 and CameraCullingMask's first bit is 1, this effect is shown.
 		\~Japanese 例えば、エフェクトのレイヤーが0でカリングマスクの最初のビットが1のときエフェクトは表示される。
 	*/
-	virtual int GetLayer(Handle handle) = 0;
+	virtual int32_t GetLayer(Handle handle) = 0;
 
 	/**
 		@brief
@@ -4489,13 +4519,8 @@ public:
 		@note
 		\~English	It is not required if Update is called.
 		\~Japanese	Updateを実行する際は、実行する必要はない。
-
-		@param ViewerPosition
-		\~English
-		Position of effects viewer to calculate distance of Level of Details system.
-		Normally should be set the same position which is passed in translation of camera matrix.
 	*/
-	virtual void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) = 0;
+	virtual void BeginUpdate() = 0;
 
 	/**
 		@brief

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
@@ -662,7 +662,7 @@ void Instance::UpdateTransform(float deltaFrame)
 
 		localPosition += localVelocity;
 
-		auto matRot = RotationFunctions::CalculateRotation(rotation_values, m_pEffectNode->RotationParam, m_randObject, m_pEffectNode->GetEffect(), m_pContainer->GetRootInstance(), m_LivingTime, m_LivedTime, m_pParent, m_pEffectNode->DynamicFactor, m_pManager->GetImplemented()->GetViewerPosition());
+		auto matRot = RotationFunctions::CalculateRotation(rotation_values, m_pEffectNode->RotationParam, m_randObject, m_pEffectNode->GetEffect(), m_pContainer->GetRootInstance(), m_LivingTime, m_LivedTime, m_pParent, m_pEffectNode->DynamicFactor, m_pManager->GetLayerParameter(GetInstanceGlobal()->GetLayer()).ViewerPosition);
 		auto scaling = ScalingFunctions::UpdateScaling(scaling_values, m_pEffectNode->ScalingParam, m_randObject, m_pEffectNode->GetEffect(), m_pContainer->GetRootInstance(), m_LivingTime, m_LivedTime, m_pParent, m_pEffectNode->DynamicFactor);
 
 		// update local fields

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGlobal.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceGlobal.h
@@ -46,7 +46,7 @@ private:
 	std::array<uint8_t, 4> m_inputTriggerCounts;
 
 	float nextDeltaFrame_ = 0.0f;
-
+	int32_t layer_ = 0;
 	void* m_userData = nullptr;
 
 	//! placement new
@@ -112,6 +112,19 @@ public:
 
 	const SIMD::Vec3f& GetTargetLocation() const;
 	void SetTargetLocation(const Vector3D& location);
+
+	void SetLayer(int32_t layer)
+	{
+		layer_ = layer;
+	}
+	int32_t GetLayer() const
+	{
+		return layer_;
+	}
+	int32_t GetLayerBits() const
+	{
+		return 1 << layer_;
+	}
 
 	void SetUserData(void* userData)
 	{

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Manager.h
@@ -24,6 +24,9 @@ namespace Effekseer
 class Manager : public IReference
 {
 public:
+	static constexpr int32_t LayerCount = 32;
+
+public:
 	/**
 		@brief
 		\~English Parameters when a manager is updated
@@ -57,18 +60,9 @@ public:
 			\~Japanese trueなら同期的に更新処理を行う。falseなら非同期的に更新処理を行う（次はDraw以外呼び出してはいけない）
 		*/
 		bool SyncUpdate = true;
-
-		/**
-			@brief
-			\~English
-			Position of effects viewer to calculate distance of Level of Details system.
-			Normally should be set the same position which is passed in translation of camera matrix.
-		 */
-		Vector3D ViewerPosition;
 	};
 
 	/**
-	@brief
 		@brief
 		\~English Parameters for Manager::Draw and Manager::DrawHandle
 		\~Japanese Manager::Draw and Manager::DrawHandleに使用するパラメーター
@@ -109,6 +103,36 @@ public:
 		bool IsSortingEffectsEnabled = false;
 
 		DrawParameter();
+	};
+	
+	/**
+		@brief
+		\~English Parameters of Manager::SetLayerParameter to be set for each layer index.
+		\~Japanese Manager::SetLayerParameterにレイヤーごとに設定するパラメーター
+	*/
+	struct LayerParameter
+	{
+		/**
+			@brief
+			\~English
+			Position of effects viewer to calculate distance of Level of Details system.
+			Normally should be set the same position which is passed in translation of camera matrix.
+			\~Japanese
+			LODシステムで使用される視点の位置。
+			通常はカメラの位置と同じ値を指定する。
+		*/
+		Vector3D ViewerPosition = {0.0f, 0.0f, 0.0f};
+		
+		/**
+			@brief
+			\~English
+			Adds given value to calculated distance from viewer which is used for LOD selection.
+			Useful for LODs debugging.
+			\~Japanese
+			LODの選択に使用される、視点からの計算された距離に加算される値。
+			LODのデバッグに役に立ちます。
+		*/
+		float DistanceBias = 0.0f;
 	};
 
 protected:
@@ -417,21 +441,27 @@ public:
 		@brief
 		\~English Returns LOD which is currently utilized for given effect
 	 */
-	virtual int GetCurrentLOD(Handle handle) = 0;
+	virtual int32_t GetCurrentLOD(Handle handle) = 0;
 
 	/**
 		@brief
-		\~English Returns current LOD distance bias. 0 by default.
+		\~English Returns current specified LOD parameters.
+		\~Japanese 現在指定されているLODパラメータを返します
 	 */
-	virtual float GetLODDistanceBias() const = 0;
+	virtual const LayerParameter& GetLayerParameter(int32_t layer) const = 0;
 
 	/**
 		@brief
-		\~English
-		Adds given value to calculated distance from viewer which is used for LOD selection.
-		Useful for LODs debugging.
+		\~English Set layer parameters.
+		\~Japanese レイヤーパラメータを設定する。
+		@param	layer
+		\~English	Layer index
+		\~Japanese	レイヤーのインデックス
+		@param	layerParameter
+		\~English	Layer parameters
+		\~Japanese	レイヤーパラメータ
 	 */
-	virtual void SetLODDistanceBias(float distanceBias) = 0;
+	virtual void SetLayerParameter(int32_t layer, const LayerParameter& layerParameter) = 0;
 
 	/**
 		@brief	エフェクトのインスタンスに設定されている行列を取得する。
@@ -622,7 +652,7 @@ public:
 		\~English For example, if effect's layer is 1 and CameraCullingMask's first bit is 1, this effect is shown.
 		\~Japanese 例えば、エフェクトのレイヤーが0でカリングマスクの最初のビットが1のときエフェクトは表示される。
 	*/
-	virtual int GetLayer(Handle handle) = 0;
+	virtual int32_t GetLayer(Handle handle) = 0;
 
 	/**
 		@brief
@@ -739,13 +769,8 @@ public:
 		@note
 		\~English	It is not required if Update is called.
 		\~Japanese	Updateを実行する際は、実行する必要はない。
-
-		@param ViewerPosition
-		\~English
-		Position of effects viewer to calculate distance of Level of Details system.
-		Normally should be set the same position which is passed in translation of camera matrix.
 	*/
-	virtual void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) = 0;
+	virtual void BeginUpdate() = 0;
 
 	/**
 		@brief

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ManagerImplemented.h
@@ -53,8 +53,6 @@ private:
 		bool IsPreupdated = false;
 		int32_t StartFrame = 0;
 
-		int32_t Layer = 0;
-
 		//! a time (by 1/60) to progress an effect when Update is called
 		float NextUpdateFrame = 0.0f;
 
@@ -110,7 +108,7 @@ private:
 
 		void SetGlobalMatrix(const SIMD::Mat43f& mat);
 
-		void UpdateLevelOfDetails(const Vector3D& viewerPosition, float lodDistanceBias);
+		void UpdateLevelOfDetails(const LayerParameter& loadParameter);
 
 	private:
 		SIMD::Mat43f GlobalMatrix;
@@ -192,8 +190,7 @@ private:
 
 	int m_randMax;
 
-	Vector3D m_ViewerPosition;
-	float m_LodDistanceBias = 0.0F;
+	std::array<LayerParameter, LayerCount> m_layerParameters;
 
 	std::queue<std::pair<SoundTag, SoundPlayer::InstanceParameter>> m_requestedSounds;
 	std::mutex m_soundMutex;
@@ -327,9 +324,9 @@ public:
 
 	int GetCurrentLOD(Handle handle) override;
 
-	float GetLODDistanceBias() const override;
+	const LayerParameter& GetLayerParameter(int32_t layer) const override;
 
-	void SetLODDistanceBias(float distanceBias) override;
+	void SetLayerParameter(int32_t layer, const LayerParameter& layerParameter) override;
 
 	Matrix43 GetMatrix(Handle handle) override;
 
@@ -377,7 +374,7 @@ public:
 
 	bool GetSpawnDisabled(Handle handle) override;
 
-	int GetLayer(Handle handle) override;
+	int32_t GetLayer(Handle handle) override;
 
 	void SetLayer(Handle handle, int32_t layer) override;
 
@@ -407,7 +404,7 @@ public:
 
 	void DoUpdate(const UpdateParameter& parameter);
 
-	void BeginUpdate(const Vector3D& ViewerPosition = Vector3D(0.0, 0.0, 0.0)) override;
+	void BeginUpdate() override;
 
 	void EndUpdate() override;
 
@@ -481,11 +478,6 @@ public:
 	void UnlockRendering() override;
 
 	void RequestToPlaySound(Instance* instance, const EffectNodeImplemented* node);
-
-	const Vector3D& GetViewerPosition() const
-	{
-		return m_ViewerPosition;
-	}
 
 	ManagerImplemented* GetImplemented() override
 	{

--- a/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
+++ b/Dev/Cpp/Test/Runtime/EffectPlatform.cpp
@@ -200,9 +200,13 @@ bool EffectPlatform::Update()
 	if (!DoEvent())
 		return false;
 
+	Effekseer::Manager::LayerParameter layerParameter;
+	layerParameter.ViewerPosition = renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0);
+	manager_->SetLayerParameter(0, layerParameter);
+
 	if (this->initParam_.IsUpdatedByHandle)
 	{
-		manager_->BeginUpdate(renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0));
+		manager_->BeginUpdate();
 
 		for (auto h : effectHandles_)
 		{
@@ -214,7 +218,6 @@ bool EffectPlatform::Update()
 	else
 	{
 		Effekseer::Manager::UpdateParameter updateParameter;
-		updateParameter.ViewerPosition = renderer_ != nullptr ? renderer_->GetCameraPosition() : Effekseer::Vector3D(0.0, 0.0, 0.0);
 		updateParameter.UpdateInterval = 0.0;
 		manager_->Update(updateParameter);
 	}

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
@@ -606,10 +606,14 @@ void EffectRenderer::PlayEffect()
 
 void EffectRenderer::UpdatePaused()
 {
+	Effekseer::Manager::LayerParameter layerParameter;
+	layerParameter.ViewerPosition = renderer_->GetCameraPosition();
+	layerParameter.DistanceBias = lodDistanceBias_;
+	manager_->SetLayerParameter(0, layerParameter);
+
 	Effekseer::Manager::UpdateParameter updateParameter;
 	updateParameter.DeltaFrame = 0.0F;
 	updateParameter.UpdateInterval = 0.0f;
-	updateParameter.ViewerPosition = renderer_->GetCameraPosition();
 	manager_->Update(updateParameter);
 }
 
@@ -720,9 +724,13 @@ void EffectRenderer::Update()
 			}
 		}
 
+		Effekseer::Manager::LayerParameter layerParameter;
+		layerParameter.ViewerPosition = renderer_->GetCameraPosition();
+		layerParameter.DistanceBias = lodDistanceBias_;
+		manager_->SetLayerParameter(0, layerParameter);
+
 		Effekseer::Manager::UpdateParameter updateParameter;
 		updateParameter.DeltaFrame = (float)m_step;
-		updateParameter.ViewerPosition = renderer_->GetCameraPosition();
 		updateParameter.UpdateInterval = 0.0;
 		manager_->Update(updateParameter);
 
@@ -774,7 +782,7 @@ void EffectRenderer::Update(int32_t frame)
 
 void EffectRenderer::SetLODDistanceBias(float distanceBias)
 {
-	manager_->SetLODDistanceBias(distanceBias);
+	lodDistanceBias_ = distanceBias;
 }
 
 void EffectRenderer::Render(std::shared_ptr<RenderImage> renderImage)
@@ -1039,8 +1047,12 @@ void EffectRenderer::ResetEffect()
 	}
 	handles_.clear();
 
+	Effekseer::Manager::LayerParameter layerParameter;
+	layerParameter.ViewerPosition = renderer_->GetCameraPosition();
+	layerParameter.DistanceBias = lodDistanceBias_;
+	manager_->SetLayerParameter(0, layerParameter);
+
 	Effekseer::Manager::UpdateParameter updateParameter;
-	updateParameter.ViewerPosition = renderer_->GetCameraPosition();
 	manager_->Update(updateParameter);
 }
 

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.h
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.h
@@ -170,6 +170,8 @@ protected:
 	EffectRendererParameter parameter_;
 	Effekseer::Tool::PostEffectParameter postEffectParameter_;
 
+	float lodDistanceBias_ = 0.0f;
+
 	bool UpdateBackgroundMesh(const Color& backgroundColor);
 
 	void CopyToBack();

--- a/Examples/DirectX11/main.cpp
+++ b/Examples/DirectX11/main.cpp
@@ -115,11 +115,15 @@ int main(int argc, char** argv)
 			// エフェクトの移動
 			manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+			// Set layer parameters
+			// レイヤーパラメータの設定
+			Effekseer::Manager::LayerParameter layerParameter;
+			layerParameter.ViewerPosition = viewerPosition;
+			manager->SetLayerParameter(0, layerParameter);
+
 			// Update the manager
 			// マネージャーの更新
 			Effekseer::Manager::UpdateParameter updateParameter;
-			updateParameter.ViewerPosition = viewerPosition;
-
 			manager->Update(updateParameter);
 
 			// Ececute functions about DirectX

--- a/Examples/DirectX12/main.cpp
+++ b/Examples/DirectX12/main.cpp
@@ -137,11 +137,15 @@ int main(int argc, char** argv)
 			// エフェクトの移動
 			manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+			// Set layer parameters
+			// レイヤーパラメータの設定
+			Effekseer::Manager::LayerParameter layerParameter;
+			layerParameter.ViewerPosition = viewerPosition;
+			manager->SetLayerParameter(0, layerParameter);
+
 			// Update the manager
 			// マネージャーの更新
 			Effekseer::Manager::UpdateParameter updateParameter;
-			updateParameter.ViewerPosition = viewerPosition;
-
 			manager->Update(updateParameter);
 
 			// Update a time

--- a/Examples/DirectX9/main.cpp
+++ b/Examples/DirectX9/main.cpp
@@ -115,11 +115,15 @@ int main(int argc, char** argv)
 			// エフェクトの移動
 			manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+			// Set layer parameters
+			// レイヤーパラメータの設定
+			Effekseer::Manager::LayerParameter layerParameter;
+			layerParameter.ViewerPosition = viewerPosition;
+			manager->SetLayerParameter(0, layerParameter);
+
 			// Update the manager
 			// マネージャーの更新
 			Effekseer::Manager::UpdateParameter updateParameter;
-			updateParameter.ViewerPosition = viewerPosition;
-
 			manager->Update(updateParameter);
 
 			// Ececute functions about DirectX

--- a/Examples/Metal/main.mm
+++ b/Examples/Metal/main.mm
@@ -106,11 +106,15 @@ int main(int argc, char** argv)
 		// エフェクトの移動
 		manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+		// Set layer parameters
+		// レイヤーパラメータの設定
+		Effekseer::Manager::LayerParameter layerParameter;
+		layerParameter.ViewerPosition = viewerPosition;
+		manager->SetLayerParameter(0, layerParameter);
+
 		// Update the manager
 		// マネージャーの更新
 		Effekseer::Manager::UpdateParameter updateParameter;
-		updateParameter.ViewerPosition = viewerPosition;
-
 		manager->Update(updateParameter);
 
 		// Update a time

--- a/Examples/OpenGL/main.cpp
+++ b/Examples/OpenGL/main.cpp
@@ -83,11 +83,15 @@ int main(int argc, char** argv)
 		// エフェクトの移動
 		manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+		// Set layer parameters
+		// レイヤーパラメータの設定
+		Effekseer::Manager::LayerParameter layerParameter;
+		layerParameter.ViewerPosition = viewerPosition;
+		manager->SetLayerParameter(0, layerParameter);
+
 		// Update the manager
 		// マネージャーの更新
 		Effekseer::Manager::UpdateParameter updateParameter;
-		updateParameter.ViewerPosition = viewerPosition;
-
 		manager->Update(updateParameter);
 
 		// Ececute functions about DirectX

--- a/Examples/Vulkan/main.cpp
+++ b/Examples/Vulkan/main.cpp
@@ -126,11 +126,15 @@ int main(int argc, char** argv)
 			// エフェクトの移動
 			manager->AddLocation(handle, ::Effekseer::Vector3D(0.2f, 0.0f, 0.0f));
 
+			// Set layer parameters
+			// レイヤーパラメータの設定
+			Effekseer::Manager::LayerParameter layerParameter;
+			layerParameter.ViewerPosition = viewerPosition;
+			manager->SetLayerParameter(0, layerParameter);
+
 			// Update the manager
 			// マネージャーの更新
 			Effekseer::Manager::UpdateParameter updateParameter;
-			updateParameter.ViewerPosition = viewerPosition;
-
 			manager->Update(updateParameter);
 
 			// Update a time


### PR DESCRIPTION
There is a problem with the current LOD API.

If the ViewerPosition is specified in Manager::Update, multiple worlds (each with its own camera) are not possible.

Therefore, since Effekseer has a mechanism called "Layer" to establish multiple worlds, we propose to use this mechanism for LOD.

An example code would look like this
```cpp
for (int i = 0; i < worldCount; i++)
{
    // Set layer parameters
    Effekseer::Manager::LayerParameter layerParameter;
    layerParameter.ViewerPosition = worlds[i].viewerPosition;
    manager->SetLayerParameter(i, layerParameter);
}
// Update the manager
Effekseer::Manager::UpdateParameter updateParameter;
manager->Update(updateParameter);
```