### PR TITLE
Fix clang and Android warnings about && and overrides.

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.ClientImplemented.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.ClientImplemented.h
@@ -41,8 +41,8 @@ public:
 
 	bool Send(void* data, int32_t datasize);
 
-	void Reload(const char16_t* key, void* data, int32_t size);
-	void Reload(ManagerRef manager, const char16_t* path, const char16_t* key);
+	void Reload(const char16_t* key, void* data, int32_t size) override;
+	void Reload(ManagerRef manager, const char16_t* path, const char16_t* key) override;
 
 	bool IsConnected();
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.DefaultEffectLoader.h
@@ -18,9 +18,9 @@ public:
 
 	virtual ~DefaultEffectLoader() override;
 
-	bool Load(const char16_t* path, void*& data, int32_t& size);
+	bool Load(const char16_t* path, void*& data, int32_t& size) override;
 
-	void Unload(void* data, int32_t size);
+	void Unload(void* data, int32_t size) override;
 };
 
 } // namespace Effekseer

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
@@ -237,7 +237,7 @@ void InstanceContainer::Draw(bool recursive)
 			}
 		}
 
-		if (count > 0 && m_pEffectNode->IsRendered && (m_pGlobal->CurrentLevelOfDetails & m_pEffectNode->LODsParam.MatchingLODs) > 0 || m_pEffectNode->CanDrawWithNonMatchingLOD())
+		if ((count > 0 && m_pEffectNode->IsRendered && (m_pGlobal->CurrentLevelOfDetails & m_pEffectNode->LODsParam.MatchingLODs) > 0) || m_pEffectNode->CanDrawWithNonMatchingLOD())
 		{
 			void* userData = m_pGlobal->GetUserData();
 


### PR DESCRIPTION
Fix four methods that needed `override` specifiers, and put parentheses around a big && and II expression to silence the warning.