### PR TITLE
Add a node API GetNodeType()

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer.h
+++ b/Dev/Cpp/Effekseer/Effekseer.h
@@ -896,6 +896,20 @@ struct Gradient
 	}
 };
 
+/**
+	@brief	A type of node
+*/
+enum class EffectNodeType : int32_t
+{
+	Root = -1,
+	NoneType = 0,
+	Sprite = 2,
+	Ribbon = 3,
+	Ring = 4,
+	Model = 5,
+	Track = 6,
+};
+
 enum class TextureColorType : int32_t
 {
 	Color,
@@ -3662,13 +3676,14 @@ struct EffectBasicRenderParameter
 */
 struct EffectModelParameter
 {
-	bool Lighting;
+	int32_t ModelIndex;
+	CullingType Culling;
 };
 
 /**
-@brief	ノードインスタンス生成クラス
-@note
-エフェクトのノードの実体を生成する。
+	@brief	ノードインスタンス生成クラス
+	@note
+	エフェクトのノードの実体を生成する。
 */
 class EffectNode
 {
@@ -3681,48 +3696,53 @@ public:
 	}
 
 	/**
-	@brief	ノードが所属しているエフェクトを取得する。
+		@brief	ノードが所属しているエフェクトを取得する。
 	*/
 	virtual Effect* GetEffect() const = 0;
 
 	/**
-	@brief
-	\~English	Get a generation in the node tree. The generation increases by 1 as it moves a child node.
-	\~Japanese	ノードツリーの世代を取得する。世代は子のノードになるにしたがって1増える。
+		@brief	Get the type of this node
+	*/
+	virtual EffectNodeType GetType() const = 0;
+
+	/**
+		@brief
+		\~English	Get a generation in the node tree. The generation increases by 1 as it moves a child node.
+		\~Japanese	ノードツリーの世代を取得する。世代は子のノードになるにしたがって1増える。
 	*/
 	virtual int GetGeneration() const = 0;
 
 	/**
-	@brief	子のノードの数を取得する。
+		@brief	子のノードの数を取得する。
 	*/
 	virtual int GetChildrenCount() const = 0;
 
 	/**
-	@brief	子のノードを取得する。
+		@brief	子のノードを取得する。
 	*/
 	virtual EffectNode* GetChild(int index) const = 0;
 
 	/**
-	@brief	共通描画パラメーターを取得する。
+		@brief	共通描画パラメーターを取得する。
 	*/
 	virtual EffectBasicRenderParameter GetBasicRenderParameter() const = 0;
 
 	/**
-	@brief	共通描画パラメーターを設定する。
+		@brief	共通描画パラメーターを設定する。
 	*/
 	virtual void SetBasicRenderParameter(EffectBasicRenderParameter param) = 0;
 
 	/**
-	@brief
-	\~English	Get a model parameter
-	\~Japanese	モデルパラメーターを取得する。
+		@brief
+		\~English	Get a model parameter
+		\~Japanese	モデルパラメーターを取得する。
 	*/
 	virtual EffectModelParameter GetEffectModelParameter() = 0;
 
 	/**
-	@brief
-	\~English	Calculate a term of instances where instances exists
-	\~Japanese	インスタンスが存在する期間を計算する。
+		@brief
+		\~English	Calculate a term of instances where instances exists
+		\~Japanese	インスタンスが存在する期間を計算する。
 	*/
 	virtual EffectInstanceTerm CalculateInstanceTerm(EffectInstanceTerm& parentTerm) const = 0;
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Base.Pre.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Base.Pre.h
@@ -896,6 +896,20 @@ struct Gradient
 	}
 };
 
+/**
+	@brief	A type of node
+*/
+enum class EffectNodeType : int32_t
+{
+	Root = -1,
+	NoneType = 0,
+	Sprite = 2,
+	Ribbon = 3,
+	Ring = 4,
+	Model = 5,
+	Track = 6,
+};
+
 enum class TextureColorType : int32_t
 {
 	Color,

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Base.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Base.h
@@ -89,20 +89,6 @@ enum class eInstanceState : int32_t
 	INSTANCE_STATE_DISPOSING,
 };
 
-/**
-	@brief	A type of node
-*/
-enum class eEffectNodeType : int32_t
-{
-	Root = -1,
-	NoneType = 0,
-	Sprite = 2,
-	Ribbon = 3,
-	Ring = 4,
-	Model = 5,
-	Track = 6,
-};
-
 enum class ModelReferenceType : int32_t
 {
 	File,

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Effect.h
@@ -685,7 +685,8 @@ struct EffectBasicRenderParameter
 */
 struct EffectModelParameter
 {
-	bool Lighting;
+	int32_t ModelIndex;
+	CullingType Culling;
 };
 
 /**
@@ -709,9 +710,14 @@ public:
 	virtual Effect* GetEffect() const = 0;
 
 	/**
-	@brief
-	\~English	Get a generation in the node tree. The generation increases by 1 as it moves a child node.
-	\~Japanese	ノードツリーの世代を取得する。世代は子のノードになるにしたがって1増える。
+		@brief	Get the type of this node
+	*/
+	virtual EffectNodeType GetType() const = 0;
+
+	/**
+		@brief
+		\~English	Get a generation in the node tree. The generation increases by 1 as it moves a child node.
+		\~Japanese	ノードツリーの世代を取得する。世代は子のノードになるにしたがって1増える。
 	*/
 	virtual int GetGeneration() const = 0;
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.cpp
@@ -424,7 +424,7 @@ EffectBasicRenderParameter EffectNodeImplemented::GetBasicRenderParameter() cons
 
 	param.BlendUVDistortionIntensity = RendererCommon.BlendUVDistortionIntensity;
 
-	if (GetType() == eEffectNodeType::Model)
+	if (GetType() == EffectNodeType::Model)
 	{
 		auto pNodeModel = static_cast<const EffectNodeModel*>(this);
 		param.EnableFalloff = pNodeModel->EnableFalloff;
@@ -510,15 +510,7 @@ void EffectNodeImplemented::SetBasicRenderParameter(EffectBasicRenderParameter p
 
 EffectModelParameter EffectNodeImplemented::GetEffectModelParameter()
 {
-	EffectModelParameter param;
-	param.Lighting = false;
-
-	if (GetType() == eEffectNodeType::Model)
-	{
-		param.Lighting = RendererCommon.MaterialType == RendererMaterialType::Lighting;
-	}
-
-	return param;
+	return {};
 }
 
 //----------------------------------------------------------------------------------
@@ -526,7 +518,7 @@ EffectModelParameter EffectNodeImplemented::GetEffectModelParameter()
 //----------------------------------------------------------------------------------
 void EffectNodeImplemented::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());
@@ -756,40 +748,40 @@ EffectNodeImplemented* EffectNodeImplemented::Create(Effect* effect, EffectNode*
 {
 	EffectNodeImplemented* effectnode = nullptr;
 
-	eEffectNodeType node_type = eEffectNodeType::NoneType;
+	EffectNodeType node_type = EffectNodeType::NoneType;
 	memcpy(&node_type, pos, sizeof(int));
 
-	if (node_type == eEffectNodeType::Root)
+	if (node_type == EffectNodeType::Root)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeRoot\n");
 		effectnode = new EffectNodeRoot(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::NoneType)
+	else if (node_type == EffectNodeType::NoneType)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeNone\n");
 		effectnode = new EffectNodeImplemented(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::Sprite)
+	else if (node_type == EffectNodeType::Sprite)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeSprite\n");
 		effectnode = new EffectNodeSprite(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::Ribbon)
+	else if (node_type == EffectNodeType::Ribbon)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeRibbon\n");
 		effectnode = new EffectNodeRibbon(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::Ring)
+	else if (node_type == EffectNodeType::Ring)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeRing\n");
 		effectnode = new EffectNodeRing(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::Model)
+	else if (node_type == EffectNodeType::Model)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeModel\n");
 		effectnode = new EffectNodeModel(effect, pos);
 	}
-	else if (node_type == eEffectNodeType::Track)
+	else if (node_type == EffectNodeType::Track)
 	{
 		EffekseerPrintDebug("* Create : EffectNodeTrack\n");
 		effectnode = new EffectNodeTrack(effect, pos);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNode.h
@@ -606,9 +606,9 @@ public:
 	/**
 	@brief	ノードの種類取得
 	*/
-	virtual eEffectNodeType GetType() const
+	virtual EffectNodeType GetType() const
 	{
-		return eEffectNodeType::NoneType;
+		return EffectNodeType::NoneType;
 	}
 
 	RefPtr<RenderingUserData> GetRenderingUserData() override

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeModel.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeModel.cpp
@@ -18,7 +18,7 @@ namespace Effekseer
 
 void EffectNodeModel::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());
@@ -221,6 +221,16 @@ void EffectNodeModel::UpdateRenderedInstance(Instance& instance, InstanceGroup& 
 	}
 
 	instance.ColorInheritance = instValues._color;
+}
+
+EffectModelParameter EffectNodeModel::GetEffectModelParameter()
+{
+	EffectModelParameter param = {};
+
+	param.ModelIndex = ModelIndex;
+	param.Culling = Culling;
+
+	return param;
 }
 
 ModelRenderer::NodeParameter EffectNodeModel::GetNodeParameter(const Manager* manager, const InstanceGlobal* global)

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeModel.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeModel.h
@@ -55,10 +55,12 @@ public:
 
 	void UpdateRenderedInstance(Instance& instance, InstanceGroup& instanceGroup, Manager* manager) override;
 
-	eEffectNodeType GetType() const override
+	EffectNodeType GetType() const override
 	{
-		return eEffectNodeType::Model;
+		return EffectNodeType::Model;
 	}
+
+	EffectModelParameter GetEffectModelParameter() override;
 
 private:
 	ModelRenderer::NodeParameter GetNodeParameter(const Manager* manager, const InstanceGlobal* global);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRibbon.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRibbon.cpp
@@ -19,7 +19,7 @@ namespace Effekseer
 
 void EffectNodeRibbon::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRibbon.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRibbon.h
@@ -119,9 +119,9 @@ public:
 
 	void UpdateRenderedInstance(Instance& instance, InstanceGroup& instanceGroup, Manager* manager) override;
 
-	eEffectNodeType GetType() const override
+	EffectNodeType GetType() const override
 	{
-		return eEffectNodeType::Ribbon;
+		return EffectNodeType::Ribbon;
 	}
 };
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRing.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRing.cpp
@@ -21,7 +21,7 @@ namespace Effekseer
 
 void EffectNodeRing::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRing.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRing.h
@@ -180,9 +180,9 @@ public:
 
 	void UpdateRenderedInstance(Instance& instance, InstanceGroup& instanceGroup, Manager* manager) override;
 
-	eEffectNodeType GetType() const override
+	EffectNodeType GetType() const override
 	{
-		return eEffectNodeType::Ring;
+		return EffectNodeType::Ring;
 	}
 
 private:

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRoot.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeRoot.h
@@ -22,9 +22,9 @@ public:
 
 	~EffectNodeRoot() = default;
 
-	eEffectNodeType GetType() const
+	EffectNodeType GetType() const
 	{
-		return eEffectNodeType::Root;
+		return EffectNodeType::Root;
 	}
 };
 

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeSprite.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeSprite.cpp
@@ -20,7 +20,7 @@ namespace Effekseer
 
 void EffectNodeSprite::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeSprite.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeSprite.h
@@ -113,9 +113,9 @@ public:
 
 	void UpdateRenderedInstance(Instance& instance, InstanceGroup& instanceGroup, Manager* manager) override;
 
-	eEffectNodeType GetType() const override
+	EffectNodeType GetType() const override
 	{
-		return eEffectNodeType::Sprite;
+		return EffectNodeType::Sprite;
 	}
 
 private:

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeTrack.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeTrack.cpp
@@ -18,7 +18,7 @@ namespace Effekseer
 
 void EffectNodeTrack::LoadRendererParameter(unsigned char*& pos, const SettingRef& setting)
 {
-	eEffectNodeType type = eEffectNodeType::NoneType;
+	EffectNodeType type = EffectNodeType::NoneType;
 	memcpy(&type, pos, sizeof(int));
 	pos += sizeof(int);
 	assert(type == GetType());

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeTrack.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.EffectNodeTrack.h
@@ -128,9 +128,9 @@ public:
 
 	void UpdateRenderedInstance(Instance& instance, InstanceGroup& instanceGroup, Manager* manager) override;
 
-	eEffectNodeType GetType() const override
+	EffectNodeType GetType() const override
 	{
-		return eEffectNodeType::Track;
+		return EffectNodeType::Track;
 	}
 
 	void InitializeValues(InstanceGroupValues::Size& value, TrackSizeParameter& param, Manager* manager);

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
@@ -407,7 +407,7 @@ void Instance::Update(float deltaFrame, bool shown)
 	m_GlobalMatrix43Calculated = false;
 	m_ParentMatrix43Calculated = false;
 
-	if (is_time_step_allowed && m_pEffectNode->GetType() != eEffectNodeType::Root)
+	if (is_time_step_allowed && m_pEffectNode->GetType() != EffectNodeType::Root)
 	{
 		if (m_pEffectNode->Sound.SoundType == ParameterSoundType_Use && deltaFrame > 0)
 		{
@@ -462,7 +462,7 @@ void Instance::Update(float deltaFrame, bool shown)
 		// check whether killed?
 		bool removed = false;
 
-		if (m_pEffectNode->GetType() != eEffectNodeType::Root)
+		if (m_pEffectNode->GetType() != EffectNodeType::Root)
 		{
 			// if pass time
 			if (m_pEffectNode->CommonValues.RemoveWhenLifeIsExtinct)
@@ -627,7 +627,7 @@ void Instance::UpdateTransform(float deltaFrame)
 	assert(m_pEffectNode != nullptr);
 	assert(m_pContainer != nullptr);
 
-	if (m_pEffectNode->GetType() != eEffectNodeType::Root)
+	if (m_pEffectNode->GetType() != EffectNodeType::Root)
 	{
 		m_sequenceNumber = ((ManagerImplemented*)m_pManager)->GetSequenceNumber();
 		const auto coordinateSystem = m_pEffectNode->GetEffect()->GetSetting()->GetCoordinateSystem();
@@ -742,7 +742,7 @@ void Instance::UpdateParentMatrix(float deltaFrame)
 
 	parentPosition_ = m_pParent->GetGlobalMatrix().GetCurrent().GetTranslation();
 
-	if (m_pEffectNode->GetType() != eEffectNodeType::Root)
+	if (m_pEffectNode->GetType() != EffectNodeType::Root)
 	{
 		TranslationParentBindType tType = m_pEffectNode->CommonValues.TranslationBindType;
 		BindType rType = m_pEffectNode->CommonValues.RotationBindType;
@@ -792,8 +792,8 @@ float Instance::GetFlipbookIndexAndNextRate(const UVAnimationType& UVType, const
 		auto time = GetUVTime();
 
 		// 経過時間を取得
-		if (m_pEffectNode->GetType() == eEffectNodeType::Ribbon ||
-			m_pEffectNode->GetType() == eEffectNodeType::Track)
+		if (m_pEffectNode->GetType() == EffectNodeType::Ribbon ||
+			m_pEffectNode->GetType() == EffectNodeType::Track)
 		{
 			// is GetFirstGroup bug?
 			auto baseInstance = this->GetContainer()->GetFirstGroup()->GetFirst();

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.InstanceContainer.cpp
@@ -176,7 +176,7 @@ void InstanceContainer::Update(bool recursive, bool shown)
 //----------------------------------------------------------------------------------
 void InstanceContainer::ApplyBaseMatrix(bool recursive, const SIMD::Mat43f& mat)
 {
-	if (m_pEffectNode->GetType() != eEffectNodeType::Root)
+	if (m_pEffectNode->GetType() != EffectNodeType::Root)
 	{
 		for (InstanceGroup* group = m_headGroups; group != nullptr; group = group->NextUsedByContainer)
 		{
@@ -220,7 +220,7 @@ void InstanceContainer::RemoveForcibly(bool recursive)
 //----------------------------------------------------------------------------------
 void InstanceContainer::Draw(bool recursive)
 {
-	if (m_pEffectNode->GetType() != eEffectNodeType::Root && m_pEffectNode->GetType() != eEffectNodeType::NoneType)
+	if (m_pEffectNode->GetType() != EffectNodeType::Root && m_pEffectNode->GetType() != EffectNodeType::NoneType)
 	{
 		/* 個数計測 */
 		int32_t count = 0;


### PR DESCRIPTION
The following features have been added or modified for EffekseerForGodot

- Rename eEffectNodeType to EffectNodeType
- Export EffectNodeType and add GetNodeType()
- Modify EffectModelParameter's params
