### PR TITLE
Fix open manual error

### DIFF
--- a/Dev/Editor/EffekseerCoreGUI/GUI/Commands.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Commands.cs
@@ -569,7 +569,7 @@ namespace Effekseer.GUI
 		{
 			try
 			{
-				System.Diagnostics.Process.Start(url);
+				System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) {UseShellExecute = true});
 			}
 			catch
 			{

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Commands.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Commands.cs
@@ -569,7 +569,12 @@ namespace Effekseer.GUI
 		{
 			try
 			{
-				System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) {UseShellExecute = true});
+				var info = new System.Diagnostics.ProcessStartInfo
+				{
+					FileName = url,
+					UseShellExecute = true
+				};
+				System.Diagnostics.Process.Start(info);
 			}
 			catch
 			{

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Dock/FileBrowser.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Dock/FileBrowser.cs
@@ -721,7 +721,12 @@ namespace Effekseer.GUI.Dock
 				try
 				{
 					// open process
-					System.Diagnostics.Process.Start(fileItem.FilePath);
+					var info = new System.Diagnostics.ProcessStartInfo
+					{
+						FileName = fileItem.FilePath,
+						UseShellExecute = true
+					};
+					System.Diagnostics.Process.Start(info);
 				}
 				catch (Exception)
 				{
@@ -747,11 +752,22 @@ namespace Effekseer.GUI.Dock
 
 				if (swig.GUIManager.IsMacOSX())
 				{
-					System.Diagnostics.Process.Start("open", dirPath);
+					var info = new System.Diagnostics.ProcessStartInfo
+					{
+						FileName = "open",
+						Arguments = dirPath,
+						UseShellExecute = true
+					};
+					System.Diagnostics.Process.Start(info);
 				}
 				else
 				{
-					System.Diagnostics.Process.Start(dirPath);
+					var info = new System.Diagnostics.ProcessStartInfo
+					{
+						FileName = dirPath,
+						UseShellExecute = true
+					};
+					System.Diagnostics.Process.Start(info);
 				}
 			}
 			catch (Exception)

--- a/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/Manager.cs
@@ -82,7 +82,12 @@ namespace Effekseer.GUI
 		{
 			try
 			{
-				System.Diagnostics.Process.Start(path);
+				var info = new System.Diagnostics.ProcessStartInfo
+				{
+					FileName = path,
+					UseShellExecute = true
+				};
+				System.Diagnostics.Process.Start(info);
 			}
 			catch
 			{


### PR DESCRIPTION
In Effekseer 1.8 the manual button is broken due to change from .Net Framework to .Net Core.
https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#change-in-default-value-of-useshellexecute