### PR TITLE
Refactor release scripts

### DIFF
--- a/release_cpp.bat
+++ b/release_cpp.bat
@@ -1,62 +1,40 @@
+@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 SET RDIR_R=EffekseerForCpp
 
-rmdir %RDIR_R%
-mkdir %RDIR_R%
-
-mkdir %RDIR_R%\cmake\
+if exist "%RDIR_R%" rmdir /s /q "%RDIR_R%"
+mkdir "%RDIR_R%"
+mkdir "%RDIR_R%\cmake"
 
 echo Copy runtime
-mkdir %RDIR_R%\Examples\
+mkdir "%RDIR_R%\Examples"
+mkdir "%RDIR_R%\src"
+mkdir "%RDIR_R%\src\include"
+mkdir "%RDIR_R%\src\lib"
 
-mkdir %RDIR_R%\src
-mkdir %RDIR_R%\src\include
-mkdir %RDIR_R%\src\lib
+for %%F in (
+    "Dev\Cpp\Effekseer\Effekseer.h"
+    "Dev\Cpp\EffekseerRendererDX9\EffekseerRendererDX9.h"
+    "Dev\Cpp\EffekseerRendererDX11\EffekseerRendererDX11.h"
+    "Dev\Cpp\EffekseerRendererGL\EffekseerRendererGL.h"
+    "Dev\Cpp\EffekseerSoundXAudio2\EffekseerSoundXAudio2.h"
+    "Dev\Cpp\EffekseerSoundAL\EffekseerSoundAL.h"
+) do copy %%F "%RDIR_R%\src\include\"
 
-copy Dev\Cpp\Effekseer\Effekseer.h %RDIR_R%\src\include\.
-copy Dev\Cpp\EffekseerRendererDX9\EffekseerRendererDX9.h %RDIR_R%\src\include\.
-copy Dev\Cpp\EffekseerRendererDX11\EffekseerRendererDX11.h %RDIR_R%\src\include\.
-copy Dev\Cpp\EffekseerRendererGL\EffekseerRendererGL.h %RDIR_R%\src\include\.
-copy Dev\Cpp\EffekseerSoundXAudio2\EffekseerSoundXAudio2.h %RDIR_R%\src\include\.
-copy Dev\Cpp\EffekseerSoundAL\EffekseerSoundAL.h %RDIR_R%\src\include\.
 
-mkdir %RDIR_R%\src\Effekseer
-robocopy Dev\Cpp\Effekseer %RDIR_R%\src\Effekseer *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererDX9
-robocopy Dev\Cpp\EffekseerRendererDX9 %RDIR_R%\src\EffekseerRendererDX9 *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererDX11
-robocopy Dev\Cpp\EffekseerRendererDX11 %RDIR_R%\src\EffekseerRendererDX11 *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererDX12
-robocopy Dev\Cpp\EffekseerRendererDX12 %RDIR_R%\src\EffekseerRendererDX12 *.h *.cpp *.fx *.bat CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererGL
-robocopy Dev\Cpp\EffekseerRendererGL %RDIR_R%\src\EffekseerRendererGL *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererLLGI
-robocopy Dev\Cpp\EffekseerRendererLLGI %RDIR_R%\src\EffekseerRendererLLGI *.h *.cpp CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererCommon
-robocopy Dev\Cpp\EffekseerRendererCommon %RDIR_R%\src\EffekseerRendererCommon *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererMetal
-robocopy Dev\Cpp\EffekseerRendererMetal %RDIR_R%\src\EffekseerRendererMetal *.h *.cpp *.mm CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerRendererVulkan
-robocopy Dev\Cpp\EffekseerRendererVulkan %RDIR_R%\src\EffekseerRendererVulkan *.h *.cpp *.vert *.frag *.inl *.py CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerSoundXAudio2
-robocopy Dev\Cpp\EffekseerSoundXAudio2 %RDIR_R%\src\EffekseerSoundXAudio2 *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerSoundAL
-robocopy Dev\Cpp\EffekseerSoundAL %RDIR_R%\src\EffekseerSoundAL *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerSoundDSound
-robocopy Dev\Cpp\EffekseerSoundDSound %RDIR_R%\src\EffekseerSoundDSound *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir %RDIR_R%\src\EffekseerMaterialCompiler
-robocopy Dev\Cpp\EffekseerMaterialCompiler %RDIR_R%\src\EffekseerMaterialCompiler *.h *.cpp CMakeLists.txt /S
+call :copy_runtime Effekseer *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerRendererDX9 *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerRendererDX11 *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerRendererDX12 *.h *.cpp *.fx *.bat CMakeLists.txt
+call :copy_runtime EffekseerRendererGL *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerRendererLLGI *.h *.cpp CMakeLists.txt
+call :copy_runtime EffekseerRendererCommon *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerRendererMetal *.h *.cpp *.mm CMakeLists.txt
+call :copy_runtime EffekseerRendererVulkan *.h *.cpp *.vert *.frag *.inl *.py CMakeLists.txt
+call :copy_runtime EffekseerSoundXAudio2 *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerSoundAL *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerSoundDSound *.h *.cpp *.fx CMakeLists.txt
+call :copy_runtime EffekseerMaterialCompiler *.h *.cpp CMakeLists.txt
 
 mkdir %RDIR_R%\src\3rdParty\LLGI
 robocopy Dev\Cpp\3rdParty\LLGI %RDIR_R%\src\3rdParty\LLGI /S
@@ -80,13 +58,13 @@ copy cmake\FilterFolder.cmake %RDIR_R%\cmake\.
 
 echo Sample
 
-mkdir %RDIR%\Sample
-robocopy Release\Sample %RDIR%\Sample *.efkproj *.efkefc *.efkmodel *.txt *.png *.mqo *.fbx /S
+mkdir %RDIR_R%\Sample
+robocopy Release\Sample %RDIR_R%\Sample *.efkproj *.efkefc *.efkmodel *.txt *.png *.mqo *.fbx /S
 
 echo License
-cp LICENSE %RDIR_R%/LICENSE.txt
-cp LICENSE_RUNTIME_DIRECTX %RDIR_R%/LICENSE_RUNTIME_DIRECTX.txt
-cp LICENSE_RUNTIME_VULKAN %RDIR_R%/LICENSE_RUNTIME_VULKAN.txt
+copy LICENSE %RDIR_R%\LICENSE.txt
+copy LICENSE_RUNTIME_DIRECTX %RDIR_R%\LICENSE_RUNTIME_DIRECTX.txt
+copy LICENSE_RUNTIME_VULKAN %RDIR_R%\LICENSE_RUNTIME_VULKAN.txt
 
 echo Readme
 copy docs\Help_Cpp_Ja.html %RDIR_R%\Help_Cpp_Ja.html
@@ -98,4 +76,14 @@ copy Release\build_msvc.bat %RDIR_R%\build_msvc.bat
 
 copy Release\build_macOS.sh %RDIR_R%\build_macOS.sh
 
+goto :eof
+
+:copy_runtime
+set DIR=%1
+shift
+if not exist "%RDIR_R%\src\%DIR%" mkdir "%RDIR_R%\src\%DIR%"
+robocopy "Dev\Cpp\%DIR%" "%RDIR_R%\src\%DIR%" %* /S
+goto :eof
+
+:eof
 pause

--- a/release_cpp.sh
+++ b/release_cpp.sh
@@ -1,35 +1,24 @@
 #!/bin/bash
 set -e
 set +x
-if [ "$RDIR_R" = "" ];
-then
+
+if [ -z "$RDIR_R" ]; then
     export RDIR_R="$PWD/EffekseerForCpp"
 fi
 
-if [ "`which robocopy`" = "" ];
-then
-    function robocopy { 
-        from=$1
-        to=$2 
-        include=""
-        echo "Copy from $from to $to"
-        args=(${@:3})
-        unset "args[${#args[@]}-1]" 
-
-        for i in "${args[@]}"; 
-        do 
-            include="$include --include=\"$i\""
-            echo "Include $i"
-            
+if ! command -v robocopy >/dev/null 2>&1; then
+    robocopy() {
+        local from=$1
+        local to=$2
+        shift 2
+        local include=()
+        for i in "$@"; do
+            [ "$i" = "/S" ] && continue
+            include+=(--include="$i")
         done
-        cdir=$PWD
-        cd $from
-        
-        rsync -av --exclude=\"*\" $include . $to
-
-        cd $cdir
+        echo "Copy from $from to $to"
+        rsync -av "${include[@]}" --exclude="*" "$from/" "$to"
     }
-
 fi
 
 
@@ -40,68 +29,55 @@ mkdir -p  $RDIR_R
 mkdir -p  $RDIR_R/cmake
 
 echo Copy runtime
-mkdir -p  $RDIR_R/Examples
+mkdir -p  "$RDIR_R/Examples"
 
-mkdir -p  $RDIR_R/src
-mkdir -p  $RDIR_R/src/include
-mkdir -p  $RDIR_R/src/lib
+mkdir -p "$RDIR_R/src"
+mkdir -p "$RDIR_R/src/include"
+mkdir -p "$RDIR_R/src/lib"
+
+header_files=(
+  Dev/Cpp/Effekseer/Effekseer.h
+  Dev/Cpp/EffekseerRendererDX9/EffekseerRendererDX9.h
+  Dev/Cpp/EffekseerRendererDX11/EffekseerRendererDX11.h
+  Dev/Cpp/EffekseerRendererGL/EffekseerRendererGL.h
+  Dev/Cpp/EffekseerSoundXAudio2/EffekseerSoundXAudio2.h
+  Dev/Cpp/EffekseerSoundAL/EffekseerSoundAL.h
+)
+
+for f in "${header_files[@]}"; do
+    cp "$f" "$RDIR_R/src/include/"
+done
 
 
-cp Dev/Cpp/Effekseer/Effekseer.h $RDIR_R\src\include\.
-cp Dev/Cpp/EffekseerRendererDX9/EffekseerRendererDX9.h $RDIR_R/src/include/.
-cp Dev/Cpp/EffekseerRendererDX11/EffekseerRendererDX11.h $RDIR_R/src/include/.
-cp Dev/Cpp/EffekseerRendererGL/EffekseerRendererGL.h $RDIR_R/src/include/.
-cp Dev/Cpp/EffekseerSoundXAudio2/EffekseerSoundXAudio2.h $RDIR_R/src/include/.
-cp Dev/Cpp/EffekseerSoundAL/EffekseerSoundAL.h $RDIR_R/src/include/.
+copy_runtime() {
+    local dir=$1
+    shift
+    mkdir -p "$RDIR_R/src/$dir"
+    robocopy "Dev/Cpp/$dir" "$RDIR_R/src/$dir" "$@" /S
+}
 
+copy_runtime Effekseer *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerRendererDX9 *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerRendererDX11 *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerRendererDX12 *.h *.cpp *.fx *.bat CMakeLists.txt
+copy_runtime EffekseerRendererGL *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerRendererLLGI *.h *.cpp CMakeLists.txt
+copy_runtime EffekseerRendererCommon *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerRendererMetal *.h *.cpp *.mm CMakeLists.txt
+copy_runtime EffekseerRendererVulkan *.h *.cpp *.vert *.frag *.inl *.py CMakeLists.txt
+copy_runtime EffekseerSoundXAudio2 *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerSoundAL *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerSoundDSound *.h *.cpp *.fx CMakeLists.txt
+copy_runtime EffekseerMaterialCompiler *.h *.cpp CMakeLists.txt
 
-mkdir -p  $RDIR_R/src/Effekseer
-robocopy Dev/Cpp/Effekseer $RDIR_R/src/Effekseer *.h *.cpp *.fx CMakeLists.txt /S
+mkdir -p "$RDIR_R/src/3rdParty/LLGI"
+robocopy Dev/Cpp/3rdParty/LLGI "$RDIR_R/src/3rdParty/LLGI" /S
 
-mkdir -p  $RDIR_R/src/EffekseerRendererDX9
-robocopy Dev/Cpp/EffekseerRendererDX9 $RDIR_R/src/EffekseerRendererDX9 *.h *.cpp *.fx CMakeLists.txt /S
+mkdir -p "$RDIR_R/src/3rdParty/glslang"
+robocopy Dev/Cpp/3rdParty/glslang "$RDIR_R/src/3rdParty/glslang" /S
 
-mkdir -p  $RDIR_R/src/EffekseerRendererDX11
-robocopy Dev/Cpp/EffekseerRendererDX11 $RDIR_R/src/EffekseerRendererDX11 *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererDX12
-robocopy Dev/Cpp/EffekseerRendererDX12 $RDIR_R/src/EffekseerRendererDX12 *.h *.cpp *.fx *.bat CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererGL
-robocopy Dev/Cpp/EffekseerRendererGL $RDIR_R/src/EffekseerRendererGL *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererLLGI
-robocopy Dev/Cpp/EffekseerRendererLLGI $RDIR_R/src/EffekseerRendererLLGI *.h *.cpp CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererCommon
-robocopy Dev/Cpp/EffekseerRendererCommon $RDIR_R/src/EffekseerRendererCommon *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererMetal
-robocopy Dev/Cpp/EffekseerRendererMetal $RDIR_R/src/EffekseerRendererMetal *.h *.cpp *.mm CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerRendererVulkan
-robocopy Dev/Cpp/EffekseerRendererVulkan $RDIR_R/src/EffekseerRendererVulkan *.h *.cpp *.vert *.frag *.inl *.py CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerSoundXAudio2
-robocopy Dev/Cpp/EffekseerSoundXAudio2 $RDIR_R/src/EffekseerSoundXAudio2 *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerSoundAL
-robocopy Dev/Cpp/EffekseerSoundAL $RDIR_R/src/EffekseerSoundAL *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerSoundDSound
-robocopy Dev/Cpp/EffekseerSoundDSound $RDIR_R/src/EffekseerSoundDSound *.h *.cpp *.fx CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/EffekseerMaterialCompiler
-robocopy Dev/Cpp/EffekseerMaterialCompiler $RDIR_R/src/EffekseerMaterialCompiler *.h *.cpp CMakeLists.txt /S
-
-mkdir -p  $RDIR_R/src/3rdParty/LLGI
-robocopy Dev/Cpp/3rdParty/LLGI $RDIR_R/src/3rdParty/LLGI /S
-
-mkdir -p  $RDIR_R/src/3rdParty/glslang
-robocopy Dev/Cpp/3rdParty/glslang $RDIR_R/src/3rdParty/glslang /S
-
-mkdir -p  $RDIR_R/src/3rdParty/stb_effekseer
-robocopy Dev/Cpp/3rdParty/stb_effekseer $RDIR_R/src/3rdParty/stb_effekseer *.h
+mkdir -p "$RDIR_R/src/3rdParty/stb_effekseer"
+robocopy Dev/Cpp/3rdParty/stb_effekseer "$RDIR_R/src/3rdParty/stb_effekseer" *.h
 
 echo Samples for runtimes
 robocopy Examples $RDIR_R/Examples/ *.h *.cpp *.mm *.txt *.fx *.efk *.wav *.png /S


### PR DESCRIPTION
## Summary
- simplify shell logic in `release_cpp.sh`
- add a looped header copier and helper function in `release_cpp.sh`
- add similar refactoring for Windows batch script
- fix incorrect variable names and use `copy` instead of `cp`

## Testing
- `bash -n release_cpp.sh`