### PR TITLE
Add Linux build support for EffekseerLauncher

### DIFF
--- a/Tool/EffekseerLauncher/CMakeLists.txt
+++ b/Tool/EffekseerLauncher/CMakeLists.txt
@@ -17,4 +17,6 @@ elseif(WIN32)
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SUBSYSTEM:WINDOWS")
 
   add_executable(EffekseerLauncher src/main.cpp resources.rc)
+elseif(UNIX)
+  add_executable(EffekseerLauncher src/main.cpp)
 endif()

--- a/Tool/EffekseerLauncher/build_linux.sh
+++ b/Tool/EffekseerLauncher/build_linux.sh
@@ -1,0 +1,3 @@
+cmake -B build_linux -S .
+cd build_linux
+cmake --build . --config Release

--- a/build.py
+++ b/build.py
@@ -123,6 +123,10 @@ def main():
         with CurrentDir('Tool/EffekseerLauncher'):
             run_command('sh build_macosx.sh')
 
+    if is_linux():
+        with CurrentDir('Tool/EffekseerLauncher'):
+            run_command('sh build_linux.sh')
+
     if env['IGNORE_BUILD'] == '0':
         os.makedirs('build', exist_ok=True)
 


### PR DESCRIPTION
## Summary
- enable Linux build in `CMakeLists.txt`
- add `build_linux.sh` helper script
- run Linux build from `build.py`

## Testing
- `python3 -m unittest Script/test_screenshot.py -v`
