### PR TITLE
Fix release_tool samples for Linux

### DIFF
--- a/release_tool.sh
+++ b/release_tool.sh
@@ -18,7 +18,8 @@ if ! command -v robocopy >/dev/null; then
             echo "Include $p"
         done
         echo "Copy from $from to $to"
-        rsync -av --exclude='*' "${include[@]}" "$from/" "$to"
+        # Ensure directories are included so files can be copied recursively
+        rsync -av --include='*/' "${include[@]}" --exclude='*' "$from/" "$to"
     }
 fi
 


### PR DESCRIPTION
## Summary
- ensure sample files are copied recursively when running `release_tool.sh`

## Testing
- `bash -n release_tool.sh`
- `python3 -m py_compile release_tool.py`
- `python3 build.py --help` *(fails: `Failed cmake ...`)*