### PR TITLE
Enable Linux tool packaging

### DIFF
--- a/Tool/EffekseerLauncher/src/main.cpp
+++ b/Tool/EffekseerLauncher/src/main.cpp
@@ -129,9 +129,11 @@ int mainLoop(int argc, char* argv[])
 	std::string cmd;
 
 #ifdef _WIN32
-	cmd = ".\\bin\\Effekseer.exe";
+        cmd = ".\\bin\\Effekseer.exe";
+#elif defined(__APPLE__)
+        cmd = "../Resources/Effekseer";
 #else
-	cmd = "../Resources/Effekseer";
+        cmd = "./bin/Effekseer";
 #endif
 
 	for (int i = 1; i < argc; i++)

--- a/release_tool.sh
+++ b/release_tool.sh
@@ -3,7 +3,10 @@ set -e
 set +x
 
 : "${RDIR:=$PWD/EffekseerTool}"
-BIN_DIR="$RDIR/Tool"
+BIN_DIR="$RDIR/Tool/bin"
+SCRIPT_DIR="$BIN_DIR/scripts/export"
+TOOLS_DIR="$BIN_DIR/tools"
+RES_DIR="$BIN_DIR/resources"
 SAMPLE_DIR="$RDIR/Sample"
 
 if ! command -v robocopy >/dev/null; then
@@ -24,13 +27,39 @@ if ! command -v robocopy >/dev/null; then
 fi
 
 rm -rf "$RDIR"
-mkdir -p "$BIN_DIR"
+mkdir -p "$SCRIPT_DIR" "$TOOLS_DIR" "$RES_DIR"
 
 echo "Compile Editor"
 
 echo "Copy application"
-cp -Rv Dev/release "$BIN_DIR"
+cp -Rv Dev/release/. "$BIN_DIR"
 rm -rf "$BIN_DIR/linux-x64" "$BIN_DIR/publish"
+if [ -f Dev/release/scripts/export/Default.cs ]; then
+    mkdir -p "$SCRIPT_DIR"
+    cp -v Dev/release/scripts/export/Default.cs "$SCRIPT_DIR"
+fi
+
+for f in fbxToEffekseerCurveConverter fbxToEffekseerModelConverter libfbxsdk.so; do
+    if [ -f "Dev/release/tools/$f" ]; then
+        cp -v "Dev/release/tools/$f" "$TOOLS_DIR"
+    fi
+done
+
+for compiler in GL Metal; do
+    if [ -f "Dev/release/tools/EffekseerMaterialCompiler${compiler}.dll" ]; then
+        cp -v "Dev/release/tools/EffekseerMaterialCompiler${compiler}.dll" "$TOOLS_DIR"
+    fi
+    if [ -f "Dev/release/tools/libEffekseerMaterialCompiler${compiler}.so" ]; then
+        cp -v "Dev/release/tools/libEffekseerMaterialCompiler${compiler}.so" "$TOOLS_DIR"
+    fi
+done
+
+cp -Rv Dev/release/resources/. "$RES_DIR"
+
+if [ -f Tool/EffekseerLauncher/build_linux/EffekseerLauncher ]; then
+    cp Tool/EffekseerLauncher/build_linux/EffekseerLauncher "$RDIR/Tool/Effekseer"
+    chmod +x "$RDIR/Tool/Effekseer"
+fi
 
 echo "Sample"
 mkdir -p "$SAMPLE_DIR"
@@ -44,3 +73,4 @@ cp -v docs/readme_sample.txt "$SAMPLE_DIR/readme.txt"
 cp -v docs/Help_Ja.html "$RDIR/Help_Ja.html"
 cp -v docs/Help_En.html "$RDIR/Help_En.html"
 cp -v LICENSE_TOOL "$RDIR/LICENSE_TOOL"
+


### PR DESCRIPTION
## Summary
- fix path for launching the editor on Linux
- update release_tool.sh to mirror Windows packaging
- limit material compiler loop to GL and Metal

## Testing
- `bash -n release_tool.sh`
- `g++ -std=c++14 -c Tool/EffekseerLauncher/src/main.cpp -o /tmp/main.o`
