### PR TITLE
Fix msbuild lookup for Visual Studio 2022

### DIFF
--- a/build.py
+++ b/build.py
@@ -145,6 +145,9 @@ if env['IGNORE_BUILD'] == '0':
     os.makedirs('build', exist_ok=True)
     if isWin():
         candidates = [
+            r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe",
+            r"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
+            r"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe",
             r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe",
             r"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
             r"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe",


### PR DESCRIPTION
## Summary
- search Visual Studio 2022 installation directories for msbuild on Windows

## Testing
- `python -m py_compile build.py`


------
https://chatgpt.com/codex/tasks/task_e_68baf3001808832a8242282c637a6588