### PR TITLE
Update .NET targets to v4.8 for CI builds

### DIFF
--- a/Dev/Editor/Effekseer/Effekseer.csproj
+++ b/Dev/Editor/Effekseer/Effekseer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Effekseer</RootNamespace>
     <AssemblyName>Effekseer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/Dev/Editor/EffekseerCore/EffekseerCore.csproj
+++ b/Dev/Editor/EffekseerCore/EffekseerCore.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Effekseer</RootNamespace>
     <AssemblyName>EffekseerCore</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Dev/Editor/EffekseerCoreGUI/EffekseerCoreGUI.csproj
+++ b/Dev/Editor/EffekseerCoreGUI/EffekseerCoreGUI.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Effekseer</RootNamespace>
     <AssemblyName>EffekseerCoreGUI</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Dev/Editor/TestCSharp/TestCSharp.csproj
+++ b/Dev/Editor/TestCSharp/TestCSharp.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>TestCSharp</RootNamespace>
     <AssemblyName>TestCSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/Tool/mqoToEffekseerModelConverter/mqoToEffekseerModelConverter/mqoToEffekseerModelConverter.csproj
+++ b/Tool/mqoToEffekseerModelConverter/mqoToEffekseerModelConverter/mqoToEffekseerModelConverter.csproj
@@ -10,8 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>mqoToEffekseerModelConverter</RootNamespace>
     <AssemblyName>mqoToEffekseerModelConverter</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">


### PR DESCRIPTION
## Summary
- retarget Effekseer C# projects to .NET Framework 4.8 to use available reference assemblies in CI

## Testing
- `python3 build.py` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68bb05adb004832aa603f64434038642