### PR TITLE
Fix libpng zlib option for Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(BUILD_VIEWER)
                         -DSANITIZE_ENABLED=${SANITIZE_ENABLED}
                         -DZLIB_INCLUDE_DIRS=${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/Install/zlib/include
                         -DZLIB_INCLUDE_DIR=${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/Install/zlib/include
-                        -DPNG_BUILD_ZLIB=ON
+                        -DZLIB_ROOT=${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/Install/zlib
                         -DPNG_SHARED=OFF
                         -DPNG_EXECUTABLES=OFF
                         -DPNG_TESTS=OFF


### PR DESCRIPTION
## Summary
- replace deprecated `PNG_BUILD_ZLIB` with `ZLIB_ROOT` when configuring libpng

## Testing
- `cmake .. -DBUILD_VIEWER=ON` *(fails: No download info given for 'ExternalProject_zlib'; git submodule fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bb12384678832a8d2b0ae929de3d94