### PR TITLE
Fix macOS build by linking QuartzCore and Metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,18 @@ else()
     option(BUILD_METAL "Build metal modules" OFF)
 endif()
 
+# Link required macOS frameworks when using GLFW
+if (APPLE)
+    find_library(QUARTZ_CORE_FRAMEWORK QuartzCore)
+    if(QUARTZ_CORE_FRAMEWORK)
+        link_libraries("${QUARTZ_CORE_FRAMEWORK}")
+    endif()
+    find_library(METAL_FRAMEWORK Metal)
+    if(METAL_FRAMEWORK)
+        link_libraries("${METAL_FRAMEWORK}")
+    endif()
+endif()
+
 include(cmake/ClangFormat.cmake)
 
 if (BUILD_VIEWER)


### PR DESCRIPTION
## Summary
- link required macOS frameworks to satisfy GLFW's CAMetalLayer dependency

## Testing
- `cmake -S . -B build -DBUILD_VIEWER=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TEST=OFF -DUSE_OPENAL=OFF -DBUILD_GL=OFF`
- `cmake --build build --config Release -j 4`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a38fd74832a83961d74d07187c1