### PR TITLE
Link macOS frameworks only when using GLFW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,16 @@ else()
     option(BUILD_METAL "Build metal modules" OFF)
 endif()
 
-# Link required macOS frameworks when using GLFW
+# Collect macOS frameworks required when linking with GLFW
 if (APPLE)
     find_library(QUARTZ_CORE_FRAMEWORK QuartzCore)
-    if(QUARTZ_CORE_FRAMEWORK)
-        link_libraries("${QUARTZ_CORE_FRAMEWORK}")
-    endif()
     find_library(METAL_FRAMEWORK Metal)
+    set(GLFW_MACOS_FRAMEWORKS "")
+    if(QUARTZ_CORE_FRAMEWORK)
+        list(APPEND GLFW_MACOS_FRAMEWORKS "${QUARTZ_CORE_FRAMEWORK}")
+    endif()
     if(METAL_FRAMEWORK)
-        link_libraries("${METAL_FRAMEWORK}")
+        list(APPEND GLFW_MACOS_FRAMEWORKS "${METAL_FRAMEWORK}")
     endif()
 endif()
 
@@ -411,6 +412,11 @@ if(BUILD_VIEWER OR BUILD_EXAMPLES OR BUILD_TEST)
     else()
         set(GLFW3_LIB_DEBUG "glfw3")
         set(GLFW3_LIB_RELEASE "glfw3")
+    endif()
+
+    if(APPLE)
+        list(APPEND GLFW3_LIB_DEBUG ${GLFW_MACOS_FRAMEWORKS})
+        list(APPEND GLFW3_LIB_RELEASE ${GLFW_MACOS_FRAMEWORKS})
     endif()
 
     list(APPEND EFK_THIRDPARTY_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/Install/glfw/include)

--- a/Dev/Cpp/TestRuntimeFramework/CMakeLists.txt
+++ b/Dev/Cpp/TestRuntimeFramework/CMakeLists.txt
@@ -185,15 +185,15 @@ target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC
     ${common_lib}
-    debug glfw3d
-    optimized glfw3
+    debug "${GLFW3_LIB_DEBUG}"
+    optimized "${GLFW3_LIB_RELEASE}"
 )
 else()
 target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC
     ${common_lib}
-    glfw3
+    "${GLFW3_LIB_RELEASE}"
     dl
 )
 endif()


### PR DESCRIPTION
## Summary
- Collect macOS frameworks for GLFW and link them only to GLFW-based targets
- Update TestRuntimeFramework to use configurable GLFW link variables

## Testing
- ⚠️ `cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TEST=OFF -DBUILD_VIEWER=OFF -DBUILD_EDITOR=OFF` (missing OpenAL: target EffekseerSoundAL not created)


------
https://chatgpt.com/codex/tasks/task_e_68bb8d71da54832a98f885a491f955b6