### PR TITLE
Fix Apple linking target in viewer

### DIFF
--- a/Dev/Cpp/Viewer/CMakeLists.txt
+++ b/Dev/Cpp/Viewer/CMakeLists.txt
@@ -211,7 +211,7 @@ elseif(APPLE)
         ${CMAKE_THREAD_LIBS_INIT}
         ${OPENGL_LIBRARIES})
 
-    LinkAppleLibs(EffekseerMaterialEditor)
+    LinkAppleLibs(${PROJECT_NAME})
     set_target_properties(Viewer PROPERTIES XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME YES)
 
 else()


### PR DESCRIPTION
## Summary
- call `LinkAppleLibs` on Viewer target on macOS

## Testing
- `cmake -S . -B build -DBUILD_VIEWER=ON` *(fails: No download info given for 'ExternalProject_zlib')*

------
https://chatgpt.com/codex/tasks/task_e_68bbcfcdcfc0832a8b143b70ba335b5e