### PR TITLE
Update macOS runtime identifier for .NET publish

### DIFF
--- a/build.py
+++ b/build.py
@@ -154,9 +154,10 @@ def main():
 
         if is_mac():
             run_command('dotnet build Dev/Editor/Effekseer/Effekseer.csproj')
-            run_command('dotnet publish Dev/Editor/Effekseer/Effekseer.csproj -c Release --self-contained -r osx.10.11-x64')
-            run_command('cp -r Dev/release/osx.10.11-x64/publish/* Dev/release/')
-            run_command('rm -rf -r Dev/release/osx.10.11-x64')
+            runtime_identifier = 'osx-x64'
+            run_command(f'dotnet publish Dev/Editor/Effekseer/Effekseer.csproj -c Release --self-contained -r {runtime_identifier}')
+            run_command(f'cp -r Dev/release/{runtime_identifier}/publish/* Dev/release/')
+            run_command(f'rm -rf -r Dev/release/{runtime_identifier}')
 
         elif is_windows():
             run_command('dotnet build Dev/Editor/Effekseer/Effekseer.csproj')


### PR DESCRIPTION
## Summary
- replace the deprecated macOS runtime identifier used for publishing the editor with the supported osx-x64 RID
- update the accompanying copy and cleanup steps to use the new runtime identifier value

## Testing
- python3 -m compileall build.py

------
https://chatgpt.com/codex/tasks/task_e_68ceeacd5194832aa274b135644b064d