### PR TITLE
Add UTF-8 compile option for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ endif()
 
 if(MSVC)
     add_definitions(/MP)
+    add_compile_options(
+        $<$<COMPILE_LANGUAGE:C>:/utf-8>
+        $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
+    )
 endif()
 
 


### PR DESCRIPTION
## Summary
- add the /utf-8 compile option for MSVC builds so Effekseer sources are treated as UTF-8 and compatible with spdlog/fmt Unicode requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceeecf96d8832a804f788ed174bde3