### PR TITLE
Include LinkAppleLibs module in release build

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Effekseer)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(FilterFolder)
+include(LinkAppleLibs)
 
 option(BUILD_EXAMPLES "Build examples" ON)
 


### PR DESCRIPTION
## Summary
- include the LinkAppleLibs helper in the release CMake configuration so example projects can use it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7c182694832aa512473ac7a5c955