### PR TITLE
Fix network connection hang when target server is unavailable

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Network/Effekseer.Socket.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Network/Effekseer.Socket.cpp
@@ -153,7 +153,6 @@ bool Socket::Connect(const char* host, int32_t port)
 
 	if (ret == SocketError)
 	{
-		// If connection is not in progress, connection failed
 #if defined(EfkWinSock)
 		int error = ::WSAGetLastError();
 		if (error != WSAEWOULDBLOCK)
@@ -161,6 +160,7 @@ bool Socket::Connect(const char* host, int32_t port)
 		if (errno != EINPROGRESS)
 #endif
 		{
+			// If connection is not in progress, connection failed
 			Close();
 			return false;
 		}


### PR DESCRIPTION
Fix editor hang on Linux when connecting to unavailable server.

- Implement non-blocking socket mode during connection
- Add timeout to wait for connection completion to fail quickly when target server is unavailable