### PR TITLE
fix: export efkpkg with curves

### DIFF
--- a/Dev/Editor/EffekseerCore/Binary/Exporter.cs
+++ b/Dev/Editor/EffekseerCore/Binary/Exporter.cs
@@ -586,7 +586,7 @@ namespace Effekseer.Binary
 				}
 			};
 
-			get_curves(Core.Root);
+			get_curves(rootNode);
 
 			{
 				int index = 0;

--- a/Dev/Editor/EffekseerCore/IO/EfkPkg.cs
+++ b/Dev/Editor/EffekseerCore/IO/EfkPkg.cs
@@ -460,7 +460,7 @@ namespace Effekseer.IO
 					efkefcSave.EditorData = Core.SaveAsXmlDocument(root);
 
 					var binaryExporter = new Binary.Exporter();
-					byte[] data = efkefc.Save(binaryExporter);
+					byte[] data = efkefcSave.Save(binaryExporter);
 					File.WriteAllBytes(filePath, data);
 					File.SetLastWriteTime(filePath, file.LastWriteTime);
 				}

--- a/Dev/Editor/EffekseerCore/Utils/Misc.cs
+++ b/Dev/Editor/EffekseerCore/Utils/Misc.cs
@@ -307,6 +307,17 @@ namespace Effekseer.Utils
 						resources.Models.Add(_node.GenerationLocationValues.Model.Model);
 					}
 				}
+
+				// Enumerate used curve paths
+				if (_node.LocationValues.Type == Data.LocationValues.ParamaterType.NurbsCurve)
+				{
+					var relative_path = _node.LocationValues.NurbsCurve.FilePath.RelativePath;
+
+					if (relative_path != string.Empty)
+					{
+						resources.Curves.Add(_node.LocationValues.NurbsCurve.FilePath);
+					}
+				}
 			}
 
 			for (int i = 0; i < node.Children.Count; i++)


### PR DESCRIPTION
This PR is trying to fix export to efkpkg missing curves which metioned in https://github.com/effekseer/EffekseerForWebGL/issues/138

And it will generate the following `metafile.json` like:

```json
{
  "version": "1.80β2",
  "files": {
    "294970068327EB1AB82650929423D999-0000398D": {
      "type": "Effect",
      "relative_path": "roller.efkefc",
      "dependencies": [
        "A14B711C6CC641C3EDD4F1406D748329-00008F21",
        "FC477E9799A3B84CE614A06F2C1E5278-0001CD3B",
        "046FF082E4999AAD600E0F64C36F199F-00025A03",
        "C7462C85016095645972E4407D5CFE62-00003C90",
        "56F121FB4C3A1ADEE46EA9A3F4C9E459-00003690"
      ]
    },
    "A14B711C6CC641C3EDD4F1406D748329-00008F21": {
      "type": "Texture",
      "relative_path": "Texture/T_xiantiao_03.png"
    },
    "FC477E9799A3B84CE614A06F2C1E5278-0001CD3B": {
      "type": "Texture",
      "relative_path": "Texture/T_xiantiao_02.png"
    },
    "046FF082E4999AAD600E0F64C36F199F-00025A03": {
      "type": "Texture",
      "relative_path": "Texture/T_xiantiao_01.png"
    },
    "C7462C85016095645972E4407D5CFE62-00003C90": {
      "type": "Curve",
      "relative_path": "quxian01.fbx",
      "dependencies": ["53063C01B7861B3B24DBD2746E13F073-000009C4"]
    },
    "53063C01B7861B3B24DBD2746E13F073-000009C4": {
      "type": "Curve",
      "relative_path": "quxian01.efkcurve"
    },
    "56F121FB4C3A1ADEE46EA9A3F4C9E459-00003690": {
      "type": "Curve",
      "relative_path": "quxian02.fbx",
      "dependencies": ["CD96733643C953BB31197F169043CA90-000001F4"]
    },
    "CD96733643C953BB31197F169043CA90-000001F4": {
      "type": "Curve",
      "relative_path": "quxian02.efkcurve"
    }
  }
}
```

I am not sure whether this is a good way to fix it, because I am not familiar with CSharp and CPP.
And this fix is generated by GPT-5.2-Codex-xhigh.

This PR is tested on my mac.