### PR TITLE
fix: Remove duplicate forward declarations in CustomAllocator.h

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Utils/Effekseer.CustomAllocator.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Utils/Effekseer.CustomAllocator.h
@@ -101,32 +101,6 @@ AlignedFreeFunc GetAlignedFreeFunc();
 */
 void SetAlignedFreeFunc(AlignedFreeFunc func);
 
-/**
-	@brief
-	\~English get an allocator
-	\~Japanese メモリ確保関数を取得する。
-*/
-MallocFunc GetMallocFunc();
-
-/**
-	\~English specify an allocator
-	\~Japanese メモリ確保関数を設定する。
-*/
-void SetMallocFunc(MallocFunc func);
-
-/**
-	@brief
-	\~English get a deallocator
-	\~Japanese メモリ破棄関数を取得する。
-*/
-FreeFunc GetFreeFunc();
-
-/**
-	\~English specify a deallocator
-	\~Japanese メモリ破棄関数を設定する。
-*/
-void SetFreeFunc(FreeFunc func);
-
 template <class T>
 struct CustomAllocator
 {


### PR DESCRIPTION
## Summary

- Remove duplicate forward declarations of `GetMallocFunc`, `SetMallocFunc`, `GetFreeFunc`, and `SetFreeFunc` in `Effekseer.CustomAllocator.h`
- These four functions were declared identically twice in the same header file (first at lines 57-76, then again at lines 109-128)

Closes #940

## Test plan

- [ ] Build passes — this is a pure deletion of redundant declarations with no behavioral change