### PR TITLE
レンダラー作成後のnullチェックを追加 (Examples)

### DIFF
--- a/Examples/DirectX11/DeviceDX11.cpp
+++ b/Examples/DirectX11/DeviceDX11.cpp
@@ -200,6 +200,10 @@ void DeviceDX11::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, bool 
 	// Create a renderer of effects
 	// エフェクトのレンダラーの作成
 	efkRenderer = ::EffekseerRendererDX11::Renderer::Create(graphicsDevice, 8000);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Sprcify rendering modules
 	// 描画モジュールの設定

--- a/Examples/DirectX12/DeviceDX12.cpp
+++ b/Examples/DirectX12/DeviceDX12.cpp
@@ -150,6 +150,10 @@ void DeviceDX12::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, bool 
 	// エフェクトのレンダラーの作成
 	DXGI_FORMAT format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	efkRenderer = ::EffekseerRendererDX12::Create(graphicsDevice, &format, 1, DXGI_FORMAT_UNKNOWN, false, 8000);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Create a memory pool
 	// メモリプールの作成

--- a/Examples/DirectX9/DeviceDX9.cpp
+++ b/Examples/DirectX9/DeviceDX9.cpp
@@ -156,6 +156,10 @@ void DeviceDX9::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, bool u
 	// Create a renderer of effects
 	// エフェクトのレンダラーの作成
 	efkRenderer = ::EffekseerRendererDX9::Renderer::Create(graphicsDevice, 8000);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Sprcify rendering modules
 	// 描画モジュールの設定

--- a/Examples/Metal/DeviceMetal.mm
+++ b/Examples/Metal/DeviceMetal.mm
@@ -194,6 +194,10 @@ void DeviceMetal::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, bool
 	// エフェクトのレンダラーの作成
 	efkRenderer = ::EffekseerRendererMetal::Create(
 		8000, MTLPixelFormatBGRA8Unorm, MTLPixelFormatInvalid, false);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Create a memory pool
 	// メモリプールの作成

--- a/Examples/OpenGL/DeviceGLFW.cpp
+++ b/Examples/OpenGL/DeviceGLFW.cpp
@@ -92,6 +92,10 @@ void DeviceGLFW::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, bool 
 	// Create a renderer of effects
 	// エフェクトのレンダラーの作成
 	efkRenderer = ::EffekseerRendererGL::Renderer::Create(graphicsDevice, 8000);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Sprcify rendering modules
 	// 描画モジュールの設定

--- a/Examples/Vulkan/DeviceVulkan.cpp
+++ b/Examples/Vulkan/DeviceVulkan.cpp
@@ -144,6 +144,10 @@ void DeviceVulkan::SetupEffekseerModules(::Effekseer::ManagerRef efkManager, boo
 	renderPassInfo.RenderTextureFormats[0] = VK_FORMAT_B8G8R8A8_UNORM;
 	renderPassInfo.DepthFormat = VK_FORMAT_D24_UNORM_S8_UINT;
 	efkRenderer = ::EffekseerRendererVulkan::Create(graphicsDevice, renderPassInfo, 8000);
+	if (efkRenderer == nullptr)
+	{
+		return;
+	}
 
 	// Create a memory pool
 	// メモリプールの作成


### PR DESCRIPTION
## 概要 / Summary

サンプルコードの `SetupEffekseerModules()` において、`Renderer::Create()` の戻り値が `nullptr` の場合にnullポインタ参照が発生する問題を修正しました。

Fixes #1061 — UBSANが `Examples/OpenGL/DeviceGLFW.cpp:98` でnullポインタアクセスを検出した問題に対応。

## 変更内容 / Changes

以下の6つのサンプルファイルで、`efkRenderer` の作成後にnullチェックを追加しました：

- `Examples/OpenGL/DeviceGLFW.cpp`
- `Examples/DirectX9/DeviceDX9.cpp`
- `Examples/DirectX11/DeviceDX11.cpp`
- `Examples/DirectX12/DeviceDX12.cpp`
- `Examples/Vulkan/DeviceVulkan.cpp`
- `Examples/Metal/DeviceMetal.mm`

レンダラーの作成に失敗した場合、以降の処理を安全にスキップするため早期リターンします。

```cpp
efkRenderer = Renderer::Create(...);
if (efkRenderer == nullptr)
{
    return;
}
```

## テスト計画 / Test plan

- [ ] 正常系：レンダラー作成成功時に既存の動作が変わらないことを確認
- [ ] 異常系：UBSANを有効にしてサンプルを実行し、nullポインタ参照エラーが解消されることを確認