### PR TITLE
Fix simd bug

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_Gen.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_Gen.h
@@ -539,10 +539,10 @@ Float4 Float4::Swizzle(const Float4& in)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 Float4 Float4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	Float4 ret;
 	ret.vu[0] = 0xffffffff * X;
 	ret.vu[1] = 0xffffffff * Y;
@@ -553,7 +553,8 @@ Float4 Float4::Mask()
 
 inline uint32_t Float4::MoveMask(const Float4& in)
 {
-	return (in.vu[0] & 0x1) | (in.vu[1] & 0x2) | (in.vu[2] & 0x4) | (in.vu[3] & 0x8);
+	return ((in.vu[0] >> 31) & 0x1) | (((in.vu[1] >> 31) & 0x1) << 1) | (((in.vu[2] >> 31) & 0x1) << 2) |
+		   (((in.vu[3] >> 31) & 0x1) << 3);
 }
 
 inline Float4 Float4::Select(const Float4& mask, const Float4& sel1, const Float4& sel2)

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_NEON.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_NEON.h
@@ -425,20 +425,20 @@ inline Float4 Float4::Cross3(const Float4& lhs, const Float4& rhs)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 inline Float4 Float4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	const uint32_t in[4] = {0xffffffff * X, 0xffffffff * Y, 0xffffffff * Z, 0xffffffff * W};
 	return vld1q_f32((const float*)in);
 }
 
 inline uint32_t Float4::MoveMask(const Float4& in)
 {
-	uint16x4_t u16x4 = vmovn_u32(vreinterpretq_u32_f32(in.s));
-	uint16_t u16[4];
-	vst1_u16(u16, u16x4);
-	return (u16[0] & 1) | (u16[1] & 2) | (u16[2] & 4) | (u16[3] & 8);
+	uint32_t u32[4];
+	vst1q_u32(u32, vreinterpretq_u32_f32(in.s));
+	return ((u32[0] >> 31) & 0x1) | (((u32[1] >> 31) & 0x1) << 1) | (((u32[2] >> 31) & 0x1) << 2) |
+		   (((u32[3] >> 31) & 0x1) << 3);
 }
 
 inline Float4 Float4::Select(const Float4& mask, const Float4& sel1, const Float4& sel2)

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_SSE.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_SSE.h
@@ -418,10 +418,10 @@ inline Float4 Float4::Cross3(const Float4& lhs, const Float4& rhs)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 inline Float4 Float4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	return _mm_setr_epi32(
 		(int)(0xffffffff * X),
 		(int)(0xffffffff * Y),

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_Gen.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_Gen.h
@@ -482,10 +482,10 @@ inline Int4 Int4::ShiftRA(const Int4& lhs)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 Int4 Int4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	Int4 ret;
 	ret.vu[0] = 0xffffffff * X;
 	ret.vu[1] = 0xffffffff * Y;
@@ -496,7 +496,8 @@ Int4 Int4::Mask()
 
 inline uint32_t Int4::MoveMask(const Int4& in)
 {
-	return (in.vu[0] & 0x1) | (in.vu[1] & 0x2) | (in.vu[2] & 0x4) | (in.vu[3] & 0x8);
+	return ((in.vu[0] >> 31) & 0x1) | (((in.vu[1] >> 31) & 0x1) << 1) | (((in.vu[2] >> 31) & 0x1) << 2) |
+		   (((in.vu[3] >> 31) & 0x1) << 3);
 }
 
 inline Int4 Int4::Equal(const Int4& lhs, const Int4& rhs)

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_NEON.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_NEON.h
@@ -340,20 +340,20 @@ inline Int4 Int4::ShiftRA(const Int4& lhs)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 inline Int4 Int4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	const uint32_t in[4] = {0xffffffff * X, 0xffffffff * Y, 0xffffffff * Z, 0xffffffff * W};
 	return vreinterpretq_s32_u32(vld1q_u32(in));
 }
 
 inline uint32_t Int4::MoveMask(const Int4& in)
 {
-	uint16x4_t u16x4 = vmovn_u32(vreinterpretq_u32_s32(in.s));
-	uint16_t u16[4];
-	vst1_u16(u16, u16x4);
-	return (u16[0] & 1) | (u16[1] & 2) | (u16[2] & 4) | (u16[3] & 8);
+	uint32_t u32[4];
+	vst1q_u32(u32, vreinterpretq_u32_s32(in.s));
+	return ((u32[0] >> 31) & 0x1) | (((u32[1] >> 31) & 0x1) << 1) | (((u32[2] >> 31) & 0x1) << 2) |
+		   (((u32[3] >> 31) & 0x1) << 3);
 }
 
 inline Int4 Int4::Equal(const Int4& lhs, const Int4& rhs)

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_SSE.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_SSE.h
@@ -373,10 +373,10 @@ inline Int4 Int4::ShiftRA(const Int4& lhs)
 template <uint32_t X, uint32_t Y, uint32_t Z, uint32_t W>
 inline Int4 Int4::Mask()
 {
-	static_assert(X >= 2, "indexX is must be set 0 or 1.");
-	static_assert(Y >= 2, "indexY is must be set 0 or 1.");
-	static_assert(Z >= 2, "indexZ is must be set 0 or 1.");
-	static_assert(W >= 2, "indexW is must be set 0 or 1.");
+	static_assert(X < 2, "indexX is must be set 0 or 1.");
+	static_assert(Y < 2, "indexY is must be set 0 or 1.");
+	static_assert(Z < 2, "indexZ is must be set 0 or 1.");
+	static_assert(W < 2, "indexW is must be set 0 or 1.");
 	return _mm_setr_epi32(
 		(int)(0xffffffff * X),
 		(int)(0xffffffff * Y),

--- a/Dev/Cpp/Test/SIMD/SIMDTest.cpp
+++ b/Dev/Cpp/Test/SIMD/SIMDTest.cpp
@@ -175,6 +175,15 @@ void test_Float4()
 		Float4 ret = Float4::Select(mask, a, b);
 		ASSERT(ret == Float4(1, 2, 2, 1));
 	}
+
+	{
+		Float4 mask = Float4::Mask<0, 1, 0, 1>();
+		ASSERT(Float4::MoveMask(mask) == 0xa);
+	}
+
+	{
+		ASSERT(Float4::MoveMask(Float4(1, -2, 3, -4)) == 0xa);
+	}
 }
 
 void test_Vec2f()
@@ -430,6 +439,15 @@ void test_Int4()
 		ASSERT(Int4::MulSubLane<1>(Int4(30), a, b) == Int4(24, 18, 12, 6));
 		ASSERT(Int4::MulSubLane<2>(Int4(30), a, b) == Int4(23, 16, 9, 2));
 		ASSERT(Int4::MulSubLane<3>(Int4(30), a, b) == Int4(22, 14, 6, -2));
+	}
+
+	{
+		Int4 mask = Int4::Mask<0, 1, 0, 1>();
+		ASSERT(mask == Int4(0, -1, 0, -1));
+	}
+
+	{
+		ASSERT(Int4::MoveMask(Int4(1, -2, 3, -4)) == 0xa);
 	}
 
 	{

--- a/Dev/Cpp/Test/SIMD/msvc/SIMDTest.vcxproj
+++ b/Dev/Cpp/Test/SIMD/msvc/SIMDTest.vcxproj
@@ -128,6 +128,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\Effekseer\Effekseer</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -146,8 +147,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\Effekseer\Effekseer</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,6 +167,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\Effekseer\Effekseer</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -188,8 +190,8 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\Effekseer\Effekseer</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
```
WebGPU とは別件で、SIMD 周りの怪しい箇所を修正しました。

主な修正は 2 点です。


Float4::Mask / Int4::Mask の static_assert が逆条件になっていたため、0/1 を許すように修正しました。対象は SSE / NEON / Gen の各実装です。

Gen / NEON の MoveMask が sign bit ではなく下位ビットを見ていたため、SSE の _mm_movemask_ps と同じ意味になるように修正しました。


あわせて SIMDTest.cpp に Mask<0,1,0,1> と負値の MoveMask テストを追加し、SIMDTest.vcxproj は現在の共通ヘッダーに合わせて C++17 指定を入れました。x64 では不要な /arch:SSE2 警告も出ないよう整理しています。
```