### PR TITLE
Fix directional billboard initial and seek orientation

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.cpp
@@ -386,6 +386,7 @@ void Instance::FirstUpdate()
 
 	prevGlobalPosition_ = SIMD::Vec3f::Transform(prevPosition_, parentMatrix_);
 	prevLocalVelocity_ = SIMD::Vec3f(0, 0, 0);
+	InitializeGlobalDirection();
 
 	m_pEffectNode->InitializeRenderedInstance(*this, *ownGroup_, m_pManager);
 
@@ -624,6 +625,139 @@ SIMD::Vec3f Instance::GetGlobalDirection() const
 	return globalDirection_;
 }
 
+SIMD::Vec3f Instance::CalculateLocalAcceleration(const SIMD::Vec3f& localPosition,
+												 SIMD::Vec3f& steeringVec,
+												 InstanceTranslationState& translationState,
+												 RandObject& randObj,
+												 float livingTime,
+												 float livedTime,
+												 float deltaFrame,
+												 CoordinateSystem coordinateSystem)
+{
+	SIMD::Vec3f acc = SIMD::Vec3f(0, 0, 0);
+
+	if (m_pEffectNode->CommonValues.TranslationBindType == TranslationParentBindType::NotBind_FollowParent ||
+		m_pEffectNode->CommonValues.TranslationBindType == TranslationParentBindType::WhenCreating_FollowParent)
+	{
+		SIMD::Vec3f worldPos = SIMD::Vec3f::Transform(localPosition, parentMatrix_);
+		SIMD::Vec3f toTarget = parentPosition_ - worldPos;
+
+		if (toTarget.GetLength() > followParentParam.maxFollowSpeed)
+		{
+			toTarget = toTarget.GetNormal();
+			toTarget *= followParentParam.maxFollowSpeed;
+		}
+
+		auto prevSteering = steeringVec;
+		SIMD::Vec3f vSteering = toTarget - steeringVec;
+		vSteering *= followParentParam.steeringSpeed;
+
+		steeringVec += vSteering * deltaFrame;
+
+		if (steeringVec.GetLength() > followParentParam.maxFollowSpeed)
+		{
+			steeringVec = steeringVec.GetNormal();
+			steeringVec *= followParentParam.maxFollowSpeed;
+		}
+
+		acc = (steeringVec - prevSteering) * m_pEffectNode->m_effect->GetMaginification();
+	}
+	else
+	{
+		acc = m_pEffectNode->TranslationParam.CalculateTranslationState(
+			translationState,
+			randObj,
+			m_pEffectNode->GetEffect(),
+			m_pContainer->GetRootInstance(),
+			livingTime,
+			livedTime,
+			deltaFrame,
+			m_pParent,
+			coordinateSystem,
+			m_pEffectNode->DynamicFactor);
+
+		if (m_pEffectNode->GenerationLocation.EffectsRotation)
+		{
+			// TODO : check rotation(It seems has bugs and it can optimize it)
+			acc = SIMD::Vec3f::Transform(acc, generationLocation_.Get3x3SubMatrix());
+		}
+	}
+
+	return acc;
+}
+
+void Instance::InitializeGlobalDirection()
+{
+	if (m_pEffectNode->GetType() == EffectNodeType::Root)
+	{
+		return;
+	}
+
+	constexpr float deltaFrame = 1.0f;
+	const auto coordinateSystem = m_pEffectNode->GetEffect()->GetSetting()->GetCoordinateSystem();
+	const auto accelerationDelta = deltaFrame;
+
+	// Estimate the first frame displacement without advancing mutable instance state.
+	auto localPosition = prevPosition_;
+	auto localVelocity = prevLocalVelocity_;
+
+	auto steeringVec = steering_vec_;
+	auto translationState = translation_state_;
+	auto randObj = m_randObject;
+	auto forceField = forceField_;
+	auto localAcc = CalculateLocalAcceleration(
+		localPosition,
+		steeringVec,
+		translationState,
+		randObj,
+		livingTime_ + deltaFrame,
+		livedTime_,
+		deltaFrame,
+		coordinateSystem);
+
+	if (m_pEffectNode->LocalForceField.HasValue)
+	{
+		auto newLocalPosition = localPosition + (localVelocity * deltaFrame + localAcc * accelerationDelta);
+
+		localAcc += forceField.Update(
+			m_pEffectNode->LocalForceField,
+			newLocalPosition,
+			localVelocity,
+			m_pEffectNode->GetEffect()->GetMaginification(),
+			deltaFrame,
+			coordinateSystem);
+	}
+
+	auto estimatedLocalPosition = localPosition + (localVelocity * deltaFrame + localAcc * accelerationDelta);
+	auto estimatedGlobalPosition = estimatedLocalPosition;
+
+	if (m_pEffectNode->TranslationParam.TranslationType != ParameterTranslationType_ViewOffset)
+	{
+		estimatedGlobalPosition = SIMD::Vec3f::Transform(estimatedGlobalPosition, parentMatrix_);
+	}
+
+	auto globalDisplacement = estimatedGlobalPosition - prevGlobalPosition_;
+
+	if (m_pEffectNode->LocalForceField.IsGlobalEnabled)
+	{
+		InstanceGlobal* instanceGlobal = m_pContainer->GetRootInstance();
+		const auto globalAcc = forceField.UpdateGlobal(
+			m_pEffectNode->LocalForceField,
+			prevGlobalPosition_,
+			m_pEffectNode->GetEffect()->GetMaginification(),
+			instanceGlobal->GetTargetLocation(),
+			deltaFrame,
+			coordinateSystem);
+
+		globalDisplacement += velocity_modify_global_ * deltaFrame + globalAcc * accelerationDelta;
+	}
+
+	if (!globalDisplacement.IsZero())
+	{
+		globalDirection_ = globalDisplacement.GetNormal();
+	}
+}
+
 void Instance::UpdateTransform(float deltaFrame)
 {
 	// 計算済なら終了
@@ -653,51 +787,15 @@ void Instance::UpdateTransform(float deltaFrame)
 		SIMD::Vec3f localPosition = prevPosition_;
 		SIMD::Vec3f localVelocity = prevLocalVelocity_;
 
-		const auto calculate_acc = [&](SIMD::Vec3f& steeringVec, InstanceTranslationState& translation_state, RandObject& rand_obj, float living_time, float deltaFrame)
-		{
-			SIMD::Vec3f acc = SIMD::Vec3f(0, 0, 0);
-
-			if (m_pEffectNode->CommonValues.TranslationBindType == TranslationParentBindType::NotBind_FollowParent ||
-				m_pEffectNode->CommonValues.TranslationBindType == TranslationParentBindType::WhenCreating_FollowParent)
-			{
-				SIMD::Vec3f worldPos = SIMD::Vec3f::Transform(localPosition, parentMatrix_);
-				SIMD::Vec3f toTarget = parentPosition_ - worldPos;
-
-				if (toTarget.GetLength() > followParentParam.maxFollowSpeed)
-				{
-					toTarget = toTarget.GetNormal();
-					toTarget *= followParentParam.maxFollowSpeed;
-				}
-
-				auto prevSteering = steeringVec;
-				SIMD::Vec3f vSteering = toTarget - steeringVec;
-				vSteering *= followParentParam.steeringSpeed;
-
-				steeringVec += vSteering * deltaFrame;
-
-				if (steeringVec.GetLength() > followParentParam.maxFollowSpeed)
-				{
-					steeringVec = steeringVec.GetNormal();
-					steeringVec *= followParentParam.maxFollowSpeed;
-				}
-
-				acc = (steeringVec - prevSteering) * m_pEffectNode->m_effect->GetMaginification();
-			}
-			else
-			{
-				acc = m_pEffectNode->TranslationParam.CalculateTranslationState(translation_state, rand_obj, m_pEffectNode->GetEffect(), m_pContainer->GetRootInstance(), living_time, livedTime_, deltaFrame, m_pParent, coordinateSystem, m_pEffectNode->DynamicFactor);
-
-				if (m_pEffectNode->GenerationLocation.EffectsRotation)
-				{
-					// TODO : check rotation(It seems has bugs and it can optimize it)
-					acc = SIMD::Vec3f::Transform(acc, generationLocation_.Get3x3SubMatrix());
-				}
-			}
-
-			return acc;
-		};
-
-		auto local_acc = calculate_acc(steering_vec_, translation_state_, m_randObject, livingTime_, deltaFrame);
+		auto local_acc = CalculateLocalAcceleration(
+			localPosition,
+			steering_vec_,
+			translation_state_,
+			m_randObject,
+			livingTime_,
+			livedTime_,
+			deltaFrame,
+			coordinateSystem);
 
 		// accelaration for rotation of velocity to avoid that a velocity is zero
 		SIMD::Vec3f local_acc_rot = SIMD::Vec3f(0, 0, 0);
@@ -707,7 +805,15 @@ void Instance::UpdateTransform(float deltaFrame)
 			auto steering_vec_temp = steering_vec_;
 			auto translation_state_temp = translation_state_;
 			auto rand_obj_temp = m_randObject;
-			local_acc_rot = calculate_acc(steering_vec_temp, translation_state_temp, rand_obj_temp, livingTime_ + delta_plus, delta_plus);
+			local_acc_rot = CalculateLocalAcceleration(
+				localPosition,
+				steering_vec_temp,
+				translation_state_temp,
+				rand_obj_temp,
+				livingTime_ + delta_plus,
+				livedTime_,
+				delta_plus,
+				coordinateSystem);
 		}
 
 		SIMD::Mat43f matRot = SIMD::Mat43f::Identity;

--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.Instance.h
@@ -267,6 +267,17 @@ public:
 	SIMD::Vec3f GetGlobalDirection() const;
 
 private:
+	SIMD::Vec3f CalculateLocalAcceleration(const SIMD::Vec3f& localPosition,
+										   SIMD::Vec3f& steeringVec,
+										   InstanceTranslationState& translationState,
+										   RandObject& randObj,
+										   float livingTime,
+										   float livedTime,
+										   float deltaFrame,
+										   CoordinateSystem coordinateSystem);
+
+	void InitializeGlobalDirection();
+
 	void UpdateTransform(float deltaFrame);
 
 	void UpdateParentMatrix(float deltaFrame);

--- a/Dev/Cpp/EffekseerRendererCommon/EffekseerRendererCommon/EffekseerRenderer.CommonUtils.cpp
+++ b/Dev/Cpp/EffekseerRendererCommon/EffekseerRendererCommon/EffekseerRenderer.CommonUtils.cpp
@@ -151,9 +151,21 @@ void CalcBillboard(::Effekseer::BillboardType billboardType,
 			{
 				U = Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f);
 			}
+			else
+			{
+				U = U.GetNormal();
+			}
 
 			F = frontDir;
-			R = ::Effekseer::SIMD::Vec3f::Cross(U, F).GetNormal();
+			R = ::Effekseer::SIMD::Vec3f::Cross(U, F);
+			if (R.IsZero())
+			{
+				const auto fallbackAxis = fabsf(U.GetY()) < 0.999f
+											  ? Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f)
+											  : Effekseer::SIMD::Vec3f(1.0f, 0.0f, 0.0f);
+				R = ::Effekseer::SIMD::Vec3f::Cross(U, fallbackAxis);
+			}
+			R = R.GetNormal();
 			F = ::Effekseer::SIMD::Vec3f::Cross(R, U).GetNormal();
 		}
 

--- a/Dev/Cpp/Test/Runtime/Vertex.cpp
+++ b/Dev/Cpp/Test/Runtime/Vertex.cpp
@@ -2,6 +2,8 @@
 
 #include "../TestHelper.h"
 
+#include <cmath>
+
 namespace EffekseerRenderer
 {
 
@@ -69,5 +71,39 @@ void VertexTest()
 	// VertexTest<EffekseerRenderer::VertexDistortion>(false);
 	VertexTest<EffekseerRenderer::DynamicVertex>(false);
 }
+
+void DirectionalBillboardParallelDirectionTest()
+{
+	using namespace Effekseer::SIMD;
+
+	Effekseer::SIMD::Mat43f dst;
+	Effekseer::SIMD::Vec3f s;
+	Effekseer::SIMD::Vec3f R;
+	Effekseer::SIMD::Vec3f F;
+
+	EffekseerRenderer::CalcBillboard(
+		Effekseer::BillboardType::DirectionalBillboard,
+		dst,
+		s,
+		R,
+		F,
+		Effekseer::SIMD::Mat43f::Identity,
+		Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f),
+		Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f));
+
+	const auto isFinite = [](const Effekseer::SIMD::Vec3f& v) {
+		return std::isfinite(v.GetX()) && std::isfinite(v.GetY()) && std::isfinite(v.GetZ());
+	};
+
+	EXPECT_TRUE(isFinite(R));
+	EXPECT_TRUE(isFinite(F));
+	EXPECT_TRUE(!R.IsZero());
+	EXPECT_TRUE(!F.IsZero());
+	EXPECT_EQUAL_NEAR(Effekseer::SIMD::Vec3f::Dot(R, Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f)), 0.0f, 0.0001f);
+	EXPECT_EQUAL_NEAR(Effekseer::SIMD::Vec3f::Dot(F, Effekseer::SIMD::Vec3f(0.0f, 1.0f, 0.0f)), 0.0f, 0.0001f);
+}
+
 TestRegister Runtime_VertexTest("Runtime.Vertex", []() -> void
 								{ VertexTest(); });
+TestRegister Runtime_DirectionalBillboardParallelDirectionTest("Runtime.DirectionalBillboardParallelDirection", []() -> void
+															  { DirectionalBillboardParallelDirectionTest(); });

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.cpp
@@ -664,6 +664,7 @@ void EffectRenderer::PlayEffect()
 	}
 
 	m_time = 0;
+	initialFrameUpdated_ = false;
 	m_rootLocation.X = behavior_.PositionX;
 	m_rootLocation.Y = behavior_.PositionY;
 	m_rootLocation.Z = behavior_.PositionZ;
@@ -832,39 +833,53 @@ void EffectRenderer::Update(int32_t frame)
 		manager_->SetGpuTimer(nullptr);
 	}
 
-	if (frame <= 0)
+	auto updateInitialFrame = [this]()
 	{
 		Effekseer::Manager::UpdateParameter updateParameter;
 		updateParameter.DeltaFrame = 0.0f;
 		updateParameter.UpdateInterval = 0.0;
 		manager_->Update(updateParameter);
-	}
-	else if (frame == 1)
+		initialFrameUpdated_ = true;
+	};
+
+	if (frame <= 0)
 	{
-		Update();
+		updateInitialFrame();
 	}
 	else
 	{
-		for (size_t i = 0; i < handles_.size(); i++)
+		if (m_time == 0 && !initialFrameUpdated_)
 		{
-			manager_->SetShown(handles_[i].Handle, false);
+			updateInitialFrame();
 		}
 
-		const auto updatingTime = Effekseer::Max(0, frame - m_step);
-
-		for (int i = 0; i < updatingTime; i++)
+		if (frame == 1)
 		{
 			Update();
 		}
-
-		for (size_t i = 0; i < handles_.size(); i++)
+		else
 		{
-			manager_->SetShown(handles_[i].Handle, true);
-		}
+			for (size_t i = 0; i < handles_.size(); i++)
+			{
+				manager_->SetShown(handles_[i].Handle, false);
+			}
 
-		for (int i = 0; i < frame - updatingTime; i++)
-		{
-			Update();
+			const auto updatingTime = Effekseer::Max(0, frame - m_step);
+
+			for (int i = 0; i < updatingTime; i++)
+			{
+				Update();
+			}
+
+			for (size_t i = 0; i < handles_.size(); i++)
+			{
+				manager_->SetShown(handles_[i].Handle, true);
+			}
+
+			for (int i = 0; i < frame - updatingTime; i++)
+			{
+				Update();
+			}
 		}
 	}
 

--- a/Dev/Cpp/Viewer/3D/EffectRenderer.h
+++ b/Dev/Cpp/Viewer/3D/EffectRenderer.h
@@ -159,6 +159,7 @@ protected:
 	::Effekseer::Vector3D m_rootRotation;
 	::Effekseer::Vector3D m_rootScale;
 	int32_t m_time = 0;
+	bool initialFrameUpdated_ = false;
 	int m_step = 1;
 	std::vector<HandleHolder> handles_;
 


### PR DESCRIPTION
Initialize DirectionalBillboard movement direction before the first rendered frame, and make viewer seek/replay run the zero-delta initial update before advancing to a positive frame.

This fixes the billboard keeping its initial pose on the first frame, and prevents the direction from being lost on frame 1 after rewinding effects that use force fields.