### PR TITLE
Fix F-curve interpolation on final sampled segment

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Effekseer.FCurves.cpp
+++ b/Dev/Cpp/Effekseer/Effekseer/Effekseer.FCurves.cpp
@@ -126,7 +126,7 @@ float FCurve::GetValue(float living, float life, FCurveTimelineType type) const
 	{
 		return keys_[keys_.size() - 1];
 	}
-	else if (ind == keys_.size() - 1)
+	else if (ind == keys_.size() - 2)
 	{
 		float subF = (float)(len_ - ind * freq_);
 		float subV = keys_[ind + 1] - keys_[ind];

--- a/Dev/Cpp/Test/CMakeLists.txt
+++ b/Dev/Cpp/Test/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
       TestHelper.cpp
       Runtime/BasicRendering.h
       Runtime/BasicRendering.cpp
+      Runtime/FCurves.cpp
       Runtime/RuntimeTest.cpp
       Runtime/Performance.cpp
       Runtime/TextureFormats.cpp

--- a/Dev/Cpp/Test/Runtime/FCurves.cpp
+++ b/Dev/Cpp/Test/Runtime/FCurves.cpp
@@ -1,0 +1,70 @@
+#include <Effekseer/Effekseer.FCurves.h>
+
+#include "../TestHelper.h"
+
+namespace
+{
+
+template <class T>
+void Append(std::vector<uint8_t>& data, const T& value)
+{
+	const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+	data.insert(data.end(), bytes, bytes + sizeof(T));
+}
+
+std::vector<uint8_t> CreateFCurveData(int32_t len, int32_t freq, const std::vector<float>& keys)
+{
+	std::vector<uint8_t> data;
+
+	const int32_t edgeConstant = 0;
+	const float offsetMax = 0.0f;
+	const float offsetMin = 0.0f;
+	const int32_t offset = 0;
+	const auto count = static_cast<int32_t>(keys.size());
+
+	Append(data, edgeConstant);
+	Append(data, edgeConstant);
+	Append(data, offsetMax);
+	Append(data, offsetMin);
+	Append(data, offset);
+	Append(data, len);
+	Append(data, freq);
+	Append(data, count);
+
+	for (auto key : keys)
+	{
+		Append(data, key);
+	}
+
+	return data;
+}
+
+void TestFCurveLinearLastSegment()
+{
+	const std::vector<float> keys = {
+		0.0f,
+		10.0f,
+		20.0f,
+		30.0f,
+		40.0f,
+		50.0f,
+		60.0f,
+		70.0f,
+		80.0f,
+		90.0f,
+		95.0f,
+	};
+	const auto data = CreateFCurveData(95, 10, keys);
+
+	Effekseer::FCurve curve(0.0f);
+	curve.Load(data.data(), 1800);
+
+	EXPECT_EQUAL_NEAR(curve.GetValue(90.0f, 1.0f, Effekseer::FCurveTimelineType::Time), 90.0f, 0.0001f);
+	EXPECT_EQUAL_NEAR(curve.GetValue(94.0f, 1.0f, Effekseer::FCurveTimelineType::Time), 94.0f, 0.0001f);
+	EXPECT_EQUAL_NEAR(curve.GetValue(95.0f, 1.0f, Effekseer::FCurveTimelineType::Time), 95.0f, 0.0001f);
+}
+
+} // namespace
+
+TestRegister Runtime_FCurveLinearLastSegment("Runtime.FCurve.LinearLastSegment", []() -> void
+											{ TestFCurveLinearLastSegment(); });


### PR DESCRIPTION
Correct the runtime F-curve segment check so curves whose length is not divisible by the sampling interval use the actual final segment length. This prevents linear F-curves from slowing down near the end and snapping to the final value.

Add a regression test for the uneven final segment case.