### PR TITLE
feat: Update Effekseer and LLGI to support RG11B10_UFLOAT texture format

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/Backend/Effekseer.GraphicsDevice.h
+++ b/Dev/Cpp/Effekseer/Effekseer/Backend/Effekseer.GraphicsDevice.h
@@ -73,6 +73,9 @@ enum class TextureFormatType
 
 	//! You don't need to implement DepthTexture for a runtime
 	D32S8,
+
+	RG11B10_UFLOAT,
+
 	Unknown,
 };
 

--- a/Dev/Cpp/EffekseerRendererCommon/EffekseerRendererCommon/EffekseerRenderer.CommonUtils.cpp
+++ b/Dev/Cpp/EffekseerRendererCommon/EffekseerRendererCommon/EffekseerRenderer.CommonUtils.cpp
@@ -517,6 +517,11 @@ void CalculateAlignedTextureInformation(Effekseer::Backend::TextureFormatType fo
 		sizePerWidth = 4 * size[0];
 		height = size[1];
 	}
+	else if (format == Effekseer::Backend::TextureFormatType::RG11B10_UFLOAT)
+	{
+		sizePerWidth = 4 * size[0];
+		height = size[1];
+	}
 	else if (format == Effekseer::Backend::TextureFormatType::R8_UNORM)
 	{
 		sizePerWidth = 1 * size[0];

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI/EffekseerRendererLLGI.Renderer.cpp
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI/EffekseerRendererLLGI.Renderer.cpp
@@ -64,6 +64,9 @@ LLGI::TextureFormatType ConvertTextureFormat(Effekseer::Backend::TextureFormatTy
 	case Effekseer::Backend::TextureFormatType::B8G8R8A8_UNORM:
 		return LLGI::TextureFormatType::B8G8R8A8_UNORM;
 		break;
+	case Effekseer::Backend::TextureFormatType::RG11B10_UFLOAT:
+		return LLGI::TextureFormatType::RG11B10_UFLOAT;
+		break;
 	case Effekseer::Backend::TextureFormatType::R8_UNORM:
 		return LLGI::TextureFormatType::R8_UNORM;
 		break;

--- a/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI/GraphicsDevice.cpp
+++ b/Dev/Cpp/EffekseerRendererLLGI/EffekseerRendererLLGI/GraphicsDevice.cpp
@@ -279,6 +279,10 @@ bool Texture::Init(const Effekseer::Backend::TextureParameter& param, const Effe
 	{
 		texParam.Format = LLGI::TextureFormatType::B8G8R8A8_UNORM;
 	}
+	else if (param.Format == Effekseer::Backend::TextureFormatType::RG11B10_UFLOAT)
+	{
+		texParam.Format = LLGI::TextureFormatType::RG11B10_UFLOAT;
+	}
 	else if (param.Format == Effekseer::Backend::TextureFormatType::R8_UNORM)
 	{
 		texParam.Format = LLGI::TextureFormatType::R8_UNORM;


### PR DESCRIPTION
This PR is...

- Updated subproject commit for LLGI.
- Added RG11B10_UFLOAT to TextureFormatType in Effekseer.
- Implemented handling for RG11B10_UFLOAT in texture calculations and conversions in EffekseerRendererCommon and EffekseerRendererLLGI.