### PR TITLE
Fix material editor launch diagnostics

### DIFF
--- a/Dev/Cpp/EditorCommon/GUI/MainWindow.cpp
+++ b/Dev/Cpp/EditorCommon/GUI/MainWindow.cpp
@@ -1,12 +1,89 @@
 #include "MainWindow.h"
 #include "../Common/StringHelper.h"
 
+#include <algorithm>
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
 
 namespace Effekseer
 {
+namespace
+{
+
+bool GetPrimaryWorkarea(int& x, int& y, int& width, int& height)
+{
+	auto monitor = glfwGetPrimaryMonitor();
+	if (monitor == nullptr)
+	{
+		return false;
+	}
+
+	glfwGetMonitorWorkarea(monitor, &x, &y, &width, &height);
+	return width > 0 && height > 0;
+}
+
+bool HasVisibleAreaInAnyMonitor(const MainWindowState& state)
+{
+	int count = 0;
+	auto monitors = glfwGetMonitors(&count);
+	if (monitors == nullptr)
+	{
+		return false;
+	}
+
+	for (int i = 0; i < count; i++)
+	{
+		int x = 0;
+		int y = 0;
+		int width = 0;
+		int height = 0;
+		glfwGetMonitorWorkarea(monitors[i], &x, &y, &width, &height);
+
+		const auto visibleWidth = (std::min)(state.PosX + state.Width, x + width) - (std::max)(state.PosX, x);
+		const auto visibleHeight = (std::min)(state.PosY + state.Height, y + height) - (std::max)(state.PosY, y);
+		const auto requiredVisibleWidth = (std::min)(state.Width, 64);
+		const auto requiredVisibleHeight = (std::min)(state.Height, 64);
+
+		if (visibleWidth >= requiredVisibleWidth && visibleHeight >= requiredVisibleHeight)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void NormalizeWindowState(MainWindowState& state)
+{
+	int workareaX = 0;
+	int workareaY = 0;
+	int workareaWidth = 0;
+	int workareaHeight = 0;
+	if (!GetPrimaryWorkarea(workareaX, workareaY, workareaWidth, workareaHeight))
+	{
+		return;
+	}
+
+	state.Width = (std::max)(1, (std::min)(state.Width, workareaWidth));
+	state.Height = (std::max)(1, (std::min)(state.Height, workareaHeight));
+
+	if (state.IsMaximumMode || state.PosX <= -1000)
+	{
+		return;
+	}
+
+	if (HasVisibleAreaInAnyMonitor(state))
+	{
+		return;
+	}
+
+	state.PosX = workareaX + (workareaWidth - state.Width) / 2;
+	state.PosY = workareaY + (workareaHeight - state.Height) / 2;
+}
+
+} // namespace
 
 void MainWindow::GLFW_ContentScaleCallback(GLFWwindow* w, float xscale, float yscale)
 {
@@ -48,6 +125,8 @@ bool MainWindow::InitializeInternal(const char16_t* title, MainWindowState state
 	{
 		glfwWindowHint(GLFW_SRGB_CAPABLE, GL_TRUE);
 	}
+
+	NormalizeWindowState(state);
 
 	isFrameless = state.IsFrameless;
 	glfwWindowHint(GLFW_DECORATED, state.IsFrameless ? 0 : 1);

--- a/Dev/Cpp/IPC/IPC.h
+++ b/Dev/Cpp/IPC/IPC.h
@@ -27,7 +27,7 @@ struct CommandData
 
 	union
 	{
-		std::array<char, 260> str;
+		std::array<char, 1024> str;
 	};
 
 	bool SetStr(const char* s)

--- a/Dev/Cpp/Viewer/ProcessConnector.cpp
+++ b/Dev/Cpp/Viewer/ProcessConnector.cpp
@@ -51,13 +51,17 @@ void ProcessConnector::OpenOrCreateMaterial(const char16_t* path)
 	if (commandQueueToMaterialEditor_ == nullptr)
 		return;
 
-	char u8path[260];
+	char u8path[1024];
 
-	Effekseer::ConvertUtf16ToUtf8(u8path, 260, path);
+	Effekseer::ConvertUtf16ToUtf8(u8path, 1024, path);
 
 	IPC::CommandData commandData;
 	commandData.Type = IPC::CommandType::OpenOrCreateMaterial;
-	commandData.SetStr(u8path);
+	if (!commandData.SetStr(u8path))
+	{
+		spdlog::warn("IPC - Failed to send OpenOrCreateMaterial because the path is too long.");
+		return;
+	}
 	commandQueueToMaterialEditor_->Enqueue(&commandData);
 
 	spdlog::trace("ICP - Send - OpenOrCreateMaterial : {}", u8path);

--- a/Dev/Editor/EffekseerCoreGUI/Process/MaterialEditor.cs
+++ b/Dev/Editor/EffekseerCoreGUI/Process/MaterialEditor.cs
@@ -12,6 +12,7 @@ namespace Effekseer.Process
 	{
 		static System.Diagnostics.Process process = null;
 		static swig.ProcessConnector processConnector = null;
+		const string LaunchLogFileName = "EffekseerMaterialEditor.launch.log.txt";
 
 		public static bool Run()
 		{
@@ -20,22 +21,55 @@ namespace Effekseer.Process
 
 			try
 			{
-
 				var app = new ProcessStartInfo();
 
 				string appDirectory = GUI.Manager.GetEntryDirectory();
-				string fullPath = System.IO.Path.Combine(appDirectory, "EffekseerMaterialEditor");
+				string executableName = "EffekseerMaterialEditor";
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				{
+					executableName += ".exe";
+				}
+				string fullPath = System.IO.Path.Combine(appDirectory, executableName);
+
+				if (!System.IO.File.Exists(fullPath))
+				{
+					ShowLaunchError("Failed to start EffekseerMaterialEditor. The executable was not found.\n" + fullPath);
+					return false;
+				}
 
 				app.FileName = fullPath;
 				app.UseShellExecute = true;
-				app.Arguments = "ipc -l " + LanguageTable.Languages[LanguageTable.SelectedIndex];
+				app.WorkingDirectory = appDirectory;
+				app.Arguments = "ipc -l " + QuoteArgument(LanguageTable.Languages[LanguageTable.SelectedIndex]);
 
 				process = System.Diagnostics.Process.Start(app);
+				if (process == null)
+				{
+					ShowLaunchError("Failed to start EffekseerMaterialEditor. Process.Start returned null.\n" + fullPath);
+					return false;
+				}
+
+				if (process.WaitForExit(500))
+				{
+					int exitCode = 0;
+					try
+					{
+						exitCode = process.ExitCode;
+					}
+					catch
+					{
+					}
+
+					ShowLaunchError("EffekseerMaterialEditor exited immediately. ExitCode: " + exitCode + "\n" + fullPath);
+					process = null;
+					return false;
+				}
 
 				return IsRunning;
 			}
-			catch
+			catch (Exception e)
 			{
+				ShowLaunchError("Failed to start EffekseerMaterialEditor.\n" + e.ToString());
 				process = null;
 				return false;
 			}
@@ -43,6 +77,12 @@ namespace Effekseer.Process
 
 		public static void Update()
 		{
+			if (process != null && process.HasExited)
+			{
+				LogLaunchMessage("EffekseerMaterialEditor exited. ExitCode: " + process.ExitCode);
+				process = null;
+			}
+
 			if (processConnector != null)
 			{
 				processConnector.Update();
@@ -71,20 +111,87 @@ namespace Effekseer.Process
 			{
 				if (processConnector == null) return false;
 				if (process == null) return false;
-				return !process.HasExited;
+				try
+				{
+					return !process.HasExited;
+				}
+				catch
+				{
+					return false;
+				}
 			}
 		}
 
 		public static void OpenOrCreateMaterial(string path)
 		{
-			processConnector.OpenOrCreateMaterial(path);
+			if (!IsRunning)
+			{
+				ShowLaunchError("EffekseerMaterialEditor is not running. The material open command was not sent.\n" + path);
+				return;
+			}
+
+			try
+			{
+				processConnector.OpenOrCreateMaterial(path);
+			}
+			catch (Exception e)
+			{
+				ShowLaunchError("Failed to send a material open command to EffekseerMaterialEditor.\n" + e.ToString());
+				return;
+			}
 
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
 			{
-				if (IsIconic(process.MainWindowHandle))
-					ShowWindow(process.MainWindowHandle, 9);
-				else
-					SetForegroundWindow(process.MainWindowHandle);
+				var handle = process.MainWindowHandle;
+				if (handle != IntPtr.Zero)
+				{
+					if (IsIconic(handle))
+						ShowWindow(handle, 9);
+					else
+						SetForegroundWindow(handle);
+				}
+			}
+		}
+
+		static string QuoteArgument(string value)
+		{
+			if (value == null)
+			{
+				return "\"\"";
+			}
+
+			return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+		}
+
+		static void ShowLaunchError(string message)
+		{
+			LogLaunchMessage(message);
+			try
+			{
+				swig.GUIManager.show(message, "Error", swig.DialogStyle.Error, swig.DialogButtons.OK);
+			}
+			catch
+			{
+			}
+		}
+
+		static void LogLaunchMessage(string message)
+		{
+			try
+			{
+				var line = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + " " + message;
+
+				if (!string.IsNullOrEmpty(Utils.Logger.LogPath))
+				{
+					Utils.Logger.Write(line);
+				}
+
+				var appDirectory = GUI.Manager.GetEntryDirectory();
+				var logPath = System.IO.Path.Combine(appDirectory, LaunchLogFileName);
+				System.IO.File.AppendAllText(logPath, line + Environment.NewLine);
+			}
+			catch
+			{
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fix Material Editor launch failures that could appear as a no-op when opening `.efkmat` files.

- Recenter saved window positions when the Material Editor would otherwise restore off-screen
- Report and log Material Editor launch failures instead of silently swallowing exceptions
- Detect immediate process exits and IPC command failures
- Increase the material path IPC buffer and avoid sending truncated paths

Fixes #1169.

## Testing

- `dotnet build Dev\Editor\Effekseer\Effekseer.csproj`
- `cmake --build build --config Release --target EffekseerMaterialEditor Viewer`
- `git diff --cached --check`