### PR TITLE
Windows on ARM (ARM64/ARM64EC) に向けた修正

### DIFF
--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Base.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Base.h
@@ -6,12 +6,16 @@
 #include <cmath>
 #include <cstdint>
 
-#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#if defined(__ARM_NEON__) || defined(__ARM_NEON) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM)
 // ARMv7/ARM64 NEON
+
+// MSVC uses _M_ARM, _M_ARM64, and _M_ARM64EC to identify Windows on ARM targets.
+// ARM64EC also defines _M_X64, so ARM targets must be checked before the x64/SSE branch.
+// See: https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170 and https://techcommunity.microsoft.com/blog/windowsosplatform/getting-to-know-arm64ec-defines-and-intrinsic-functions/2957235
 
 #define EFK_SIMD_NEON
 
-#if defined(_M_ARM64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) 
 #define EFK_SIMD_NEON_ARM64
 #endif
 

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_NEON.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_NEON.h
@@ -38,10 +38,13 @@ struct alignas(16) Float4
 	{
 		s = rhs;
 	}
+	// MSVC ARM64/ARM64EC treats float32x4_t and uint32x4_t as the same type.
+	#if !(defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC)))
 	Float4(uint32x4_t rhs)
 	{
 		s = vreinterpretq_f32_u32(rhs);
 	}
+	#endif
 	Float4(float x, float y, float z, float w)
 	{
 		const float f[4] = {x, y, z, w};

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_SSE.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Float4_SSE.h
@@ -62,15 +62,15 @@ struct alignas(16) Float4
 	}
 	float GetY() const
 	{
-		return _mm_cvtss_f32(Swizzle<1, 1, 1, 1>(s).s);
+		return _mm_cvtss_f32((Swizzle<1, 1, 1, 1>(s).s));
 	}
 	float GetZ() const
 	{
-		return _mm_cvtss_f32(Swizzle<2, 2, 2, 2>(s).s);
+		return _mm_cvtss_f32((Swizzle<2, 2, 2, 2>(s).s));
 	}
 	float GetW() const
 	{
-		return _mm_cvtss_f32(Swizzle<3, 3, 3, 3>(s).s);
+		return _mm_cvtss_f32((Swizzle<3, 3, 3, 3>(s).s));
 	}
 
 	void SetX(float i)
@@ -79,15 +79,15 @@ struct alignas(16) Float4
 	}
 	void SetY(float i)
 	{
-		s = Swizzle<1, 0, 2, 3>(_mm_move_ss(Swizzle<1, 0, 2, 3>(s).s, _mm_set_ss(i))).s;
+		s = Swizzle<1, 0, 2, 3>(_mm_move_ss((Swizzle<1, 0, 2, 3>(s).s), _mm_set_ss(i))).s;
 	}
 	void SetZ(float i)
 	{
-		s = Swizzle<2, 1, 0, 3>(_mm_move_ss(Swizzle<2, 1, 0, 3>(s).s, _mm_set_ss(i))).s;
+		s = Swizzle<2, 1, 0, 3>(_mm_move_ss((Swizzle<2, 1, 0, 3>(s).s), _mm_set_ss(i))).s;
 	}
 	void SetW(float i)
 	{
-		s = Swizzle<3, 1, 2, 0>(_mm_move_ss(Swizzle<3, 1, 2, 0>(s).s, _mm_set_ss(i))).s;
+		s = Swizzle<3, 1, 2, 0>(_mm_move_ss((Swizzle<3, 1, 2, 0>(s).s), _mm_set_ss(i))).s;
 	}
 
 	template <size_t LANE>
@@ -363,7 +363,7 @@ template <size_t LANE>
 Float4 Float4::MulLane(const Float4& lhs, const Float4& rhs)
 {
 	static_assert(LANE < 4, "LANE is must be less than 4.");
-	return _mm_mul_ps(lhs.s, Swizzle<LANE, LANE, LANE, LANE>(rhs).s);
+	return _mm_mul_ps(lhs.s, (Swizzle<LANE, LANE, LANE, LANE>(rhs).s));
 }
 
 template <size_t LANE>
@@ -371,9 +371,9 @@ Float4 Float4::MulAddLane(const Float4& a, const Float4& b, const Float4& c)
 {
 	static_assert(LANE < 4, "LANE is must be less than 4.");
 #if defined(EFK_SIMD_AVX2)
-	return _mm_fmadd_ps(b.s, Swizzle<LANE, LANE, LANE, LANE>(c).s, a.s);
+	return _mm_fmadd_ps(b.s, (Swizzle<LANE, LANE, LANE, LANE>(c).s), a.s);
 #else
-	return _mm_add_ps(a.s, _mm_mul_ps(b.s, Swizzle<LANE, LANE, LANE, LANE>(c).s));
+	return _mm_add_ps(a.s, _mm_mul_ps(b.s, (Swizzle<LANE, LANE, LANE, LANE>(c).s)));
 #endif
 }
 
@@ -382,9 +382,9 @@ Float4 Float4::MulSubLane(const Float4& a, const Float4& b, const Float4& c)
 {
 	static_assert(LANE < 4, "LANE is must be less than 4.");
 #if defined(EFK_SIMD_AVX2)
-	return _mm_fnmadd_ps(b.s, Swizzle<LANE, LANE, LANE, LANE>(c).s, a.s);
+	return _mm_fnmadd_ps(b.s, (Swizzle<LANE, LANE, LANE, LANE>(c).s), a.s);
 #else
-	return _mm_sub_ps(a.s, _mm_mul_ps(b.s, Swizzle<LANE, LANE, LANE, LANE>(c).s));
+	return _mm_sub_ps(a.s, _mm_mul_ps(b.s, (Swizzle<LANE, LANE, LANE, LANE>(c).s)));
 #endif
 }
 
@@ -406,7 +406,7 @@ Float4 Float4::Swizzle(const Float4& v)
 inline Float4 Float4::Dot3(const Float4& lhs, const Float4& rhs)
 {
 	Float4 muled = lhs * rhs;
-	return _mm_add_ss(_mm_add_ss(muled.s, Float4::Swizzle<1, 1, 1, 1>(muled).s), Float4::Swizzle<2, 2, 2, 2>(muled).s);
+	return _mm_add_ss(_mm_add_ss(muled.s, (Float4::Swizzle<1, 1, 1, 1>(muled).s)), (Float4::Swizzle<2, 2, 2, 2>(muled).s));
 }
 
 inline Float4 Float4::Cross3(const Float4& lhs, const Float4& rhs)

--- a/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_SSE.h
+++ b/Dev/Cpp/Effekseer/Effekseer/SIMD/Int4_SSE.h
@@ -51,15 +51,15 @@ struct alignas(16) Int4
 	}
 	int32_t GetY() const
 	{
-		return _mm_cvtsi128_si32(Swizzle<1, 1, 1, 1>(s).s);
+		return _mm_cvtsi128_si32((Swizzle<1, 1, 1, 1>(s).s));
 	}
 	int32_t GetZ() const
 	{
-		return _mm_cvtsi128_si32(Swizzle<2, 2, 2, 2>(s).s);
+		return _mm_cvtsi128_si32((Swizzle<2, 2, 2, 2>(s).s));
 	}
 	int32_t GetW() const
 	{
-		return _mm_cvtsi128_si32(Swizzle<3, 3, 3, 3>(s).s);
+		return _mm_cvtsi128_si32((Swizzle<3, 3, 3, 3>(s).s));
 	}
 
 	void SetX(int32_t i)
@@ -68,15 +68,15 @@ struct alignas(16) Int4
 	}
 	void SetY(int32_t i)
 	{
-		s = Swizzle<1, 0, 2, 3>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps(Swizzle<1, 0, 2, 3>(s).s), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
+		s = Swizzle<1, 0, 2, 3>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps((Swizzle<1, 0, 2, 3>(s).s)), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
 	}
 	void SetZ(int32_t i)
 	{
-		s = Swizzle<2, 1, 0, 3>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps(Swizzle<2, 1, 0, 3>(s).s), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
+		s = Swizzle<2, 1, 0, 3>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps((Swizzle<2, 1, 0, 3>(s).s)), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
 	}
 	void SetW(int32_t i)
 	{
-		s = Swizzle<3, 1, 2, 0>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps(Swizzle<3, 1, 2, 0>(s).s), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
+		s = Swizzle<3, 1, 2, 0>(_mm_castps_si128(_mm_move_ss(_mm_castsi128_ps((Swizzle<3, 1, 2, 0>(s).s)), _mm_castsi128_ps(_mm_cvtsi32_si128(i))))).s;
 	}
 
 	Float4 Convert4f() const;

--- a/Dev/Cpp/EffekseerRendererDX11/EffekseerRendererDX11/EffekseerRendererDX11.RendererImplemented.h
+++ b/Dev/Cpp/EffekseerRendererDX11/EffekseerRendererDX11/EffekseerRendererDX11.RendererImplemented.h
@@ -12,7 +12,12 @@
 #include <EffekseerRendererCommon/EffekseerRenderer.StandardRenderer.h>
 
 #ifdef _WIN32
-#include <xmmintrin.h>
+	//On ARM64/ARM64EC, <xmmintrin.h> must be included indirectly through <intrin.h>.
+	#if defined(_M_IX86) || defined(_M_X64) // x86 or x64
+		#include <xmmintrin.h>
+	#elif defined(_M_ARM64) || defined(_M_ARM64EC) // ARM64 or ARM64EC
+		#include <intrin.h>
+	#endif
 #endif
 
 namespace EffekseerRendererDX11


### PR DESCRIPTION
### 修正点
- ARM64/ARM64ECにおいて適切なSIMDを利用するように修正
- ARM64向けに適切なヘッダーをincludeするように修正

### 詳細

#### Float4_SSE.h/Int4_SEE.hに関して

Float4_SSE.h/Int4_SEE.hにおいては通常ARMにおいて利用されないが、
ARM64でSSEのエミュレーションを利用する場合にコンパイルエラーが出ないように修正
理由としては以下の通り

ARM64EC では、Windows SDK の `softintrin.h` に含まれる一部の SSE intrinsic が関数形式マクロとして定義されています。 たとえば `_mm_move_ss` や `_mm_cvtss_f32` はマクロとして展開されます。 C/C++ プリプロセッサは C++ のテンプレート構文を解析する前にマクロの引数を処理するため、テンプレート引数の <...> はマクロ引数解析上のネストとして扱われません。

そのため、`Swizzle<1, 1, 1, 1>(s).s` のようなテンプレート式をマクロの引数として直接渡すと、テンプレート引数内のカンマがマクロ引数の区切りとして解釈される場合があります。 以下のコードでは _mm_cvtss_f32 に複数の引数が渡されたものとして解釈され、警告 C4002 とそれに続く構文エラーが発生します。
```
_mm_cvtss_f32(Swizzle<1, 1, 1, 1>(s).s)
```
同様に、`_mm_move_ss` の引数へテンプレート式を直接渡した場合にも同じ問題が発生します。 この問題を回避するため、テンプレート引数を含む式をこれらのマクロへ渡す際は、式全体を追加の括弧で囲みます。
```
_mm_cvtss_f32((Swizzle<1, 1, 1, 1>(s).s))

_mm_move_ss((Swizzle<1, 0, 2, 3>(s).s), _mm_set_ss(i))
```
追加の括弧によってテンプレート式全体が 1 つのマクロ引数として扱われ、テンプレート引数内のカンマがマクロ引数の区切りとして解釈されることを防止します。