### PR TITLE
Make the texture preview size adjustable

### DIFF
--- a/Dev/Editor/EffekseerCore/Data/OptionValues.cs
+++ b/Dev/Editor/EffekseerCore/Data/OptionValues.cs
@@ -242,6 +242,14 @@ namespace Effekseer.Data
 			private set;
 		}
 
+		[Key(key = "Options_TexturePreviewLines")]
+		[Undo(Undo = false)]
+		public Value.Int TexturePreviewLines
+		{
+			get;
+			private set;
+		}
+
 		[Key(key = "Options_FloatFormatDigits")]
 		[Undo(Undo = false)]
 		public Value.Int FloatFormatDigits
@@ -295,6 +303,8 @@ namespace Effekseer.Data
 
 			FileBrowserViewMode = new Value.Enum<FileViewMode>(FileViewMode.IconView);
 			FileBrowserIconSize = new Value.Int(96, 512, 48);
+			// 行数で持つと文字の大きさに追従する。既定は 3 行。
+			TexturePreviewLines = new Value.Int(3, 10, 2);
 			FloatFormatDigits =  new Value.Int(3, 9, 1);
 			AutoSaveIntervalMin = new Value.Int(2, 60, 0);
 		}

--- a/Dev/Editor/EffekseerCoreGUI/GUI/BindableComponent/PathBase.cs
+++ b/Dev/Editor/EffekseerCoreGUI/GUI/BindableComponent/PathBase.cs
@@ -116,7 +116,9 @@ namespace Effekseer.GUI.BindableComponent
 			float itemSpacing = 4;
 			float lineHeight = Manager.NativeManager.GetFrameHeight();
 			float lineSpacing = Manager.NativeManager.GetFrameHeightWithSpacing() - lineHeight;
-			float imageSize = lineHeight * 2 + lineSpacing;
+			// 画像の大きさは文字の行数で決める。文字を大きくしても比率が崩れない。
+			int previewLines = Math.Max(2, Core.Option.TexturePreviewLines.GetValue());
+			float imageSize = lineHeight * previewLines + lineSpacing * (previewLines - 1);
 			float buttonSizeX = lineHeight;
 
 			float cursorX = Manager.NativeManager.GetCursorPosX();

--- a/Dev/release/resources/languages/en/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/en/Effekseer_Options.csv
@@ -72,3 +72,5 @@ MouseMappingType_Blender_Name,Blender
 MouseMappingType_Maya_Name,Maya
 FileBrowser_ViewMode_IconView_Name,Icon view
 FileBrowser_ViewMode_ListView_Name,List view
+Options_TexturePreviewLines_Name,Texture preview size
+Options_TexturePreviewLines_Desc,"Height of the texture preview in the parameter panels, counted in text lines"

--- a/Dev/release/resources/languages/es/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/es/Effekseer_Options.csv
@@ -1,4 +1,4 @@
-Options_RenderingMode_Name,Modo renderizado
+﻿Options_RenderingMode_Name,Modo renderizado
 Options_RenderingMode_Desc,Modo renderizado de efectos
 Options_ViewerMode_Name,Modo de vista
 Options_ViewerMode_Desc,Modo de vista de la pantalla de visualización.
@@ -75,3 +75,5 @@ FileBrowser_ViewMode_ListView_Name,Vista de la lista
 Options_FloatFormatDigits_Desc,Cantidad de dígitos después del punto decimal
 RenderMode_NormalWithWireframe_Name,Normal+Malla de alambre
 RenderMode_Overdraw_Name,Sobredibujo
+Options_TexturePreviewLines_Name,Tamaño de la vista previa de textura
+Options_TexturePreviewLines_Desc,"Altura de la vista previa de textura en los paneles de parámetros, medida en líneas de texto"

--- a/Dev/release/resources/languages/ja/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/ja/Effekseer_Options.csv
@@ -1,4 +1,4 @@
-Options_RenderingMode_Name,描画モード
+﻿Options_RenderingMode_Name,描画モード
 Options_RenderingMode_Desc,ビュワーのエフェクト描画モードの設定
 Options_ViewerMode_Name,表示モード
 Options_ViewerMode_Desc,ビュワーの表示モードの設定
@@ -71,3 +71,5 @@ MouseMappingType_Blender_Name,Blender
 MouseMappingType_Maya_Name,Maya
 FileBrowser_ViewMode_IconView_Name,アイコン表示
 FileBrowser_ViewMode_ListView_Name,リスト表示
+Options_TexturePreviewLines_Name,テクスチャのプレビューの大きさ
+Options_TexturePreviewLines_Desc,パラメーター欄に出るテクスチャのプレビューの高さ。文字の行数で指定する

--- a/Dev/release/resources/languages/ru/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/ru/Effekseer_Options.csv
@@ -72,3 +72,5 @@ MouseMappingType_Blender_Name,Blender
 MouseMappingType_Maya_Name,Maya
 FileBrowser_ViewMode_IconView_Name,Значки
 FileBrowser_ViewMode_ListView_Name,Список
+Options_TexturePreviewLines_Name,Размер предпросмотра текстуры
+Options_TexturePreviewLines_Desc,"Высота предпросмотра текстуры на панелях параметров, измеряется в строках текста"

--- a/Dev/release/resources/languages/zhcn/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/zhcn/Effekseer_Options.csv
@@ -1,4 +1,4 @@
-Options_RenderingMode_Name,渲染模式
+﻿Options_RenderingMode_Name,渲染模式
 Options_RenderingMode_Desc,特效的渲染模式
 Options_ViewerMode_Name,视图模式
 Options_ViewerMode_Desc,特效窗口的视图模式
@@ -72,3 +72,5 @@ MouseMappingType_Blender_Name,Blender
 MouseMappingType_Maya_Name,Maya
 FileBrowser_ViewMode_IconView_Name,显示图标
 FileBrowser_ViewMode_ListView_Name,显示列表
+Options_TexturePreviewLines_Name,纹理预览尺寸
+Options_TexturePreviewLines_Desc,参数面板中纹理预览的高度，以文字行数计算

--- a/Dev/release/resources/languages/zhtw/Effekseer_Options.csv
+++ b/Dev/release/resources/languages/zhtw/Effekseer_Options.csv
@@ -1,4 +1,4 @@
-Options_RenderingMode_Name,渲染模式
+﻿Options_RenderingMode_Name,渲染模式
 Options_RenderingMode_Desc,特效的渲染模式
 Options_ViewerMode_Name,檢視模式
 Options_ViewerMode_Desc,特效視窗的檢視模式
@@ -72,3 +72,5 @@ MouseMappingType_Blender_Name,Blender
 MouseMappingType_Maya_Name,Maya
 FileBrowser_ViewMode_IconView_Name,顯示圖示
 FileBrowser_ViewMode_ListView_Name,顯示列表
+Options_TexturePreviewLines_Name,紋理預覽尺寸
+Options_TexturePreviewLines_Desc,參數面板中紋理預覽的高度，以文字行數計算


### PR DESCRIPTION
I had to do it because it was too small.

The thumbnail beside a texture slot in the parameter panels was fixed at two text lines tall, which is small for judging a texture at a glance. The file browser already lets you size its icons, so follow that and add a setting rather than hardcoding a new number.

The height is counted in text lines rather than pixels, so the preview keeps its proportions when the font size changes, as the old fixed value did. It defaults to three lines.

The options panel builds itself from this data model, so the control appears without further wiring.